### PR TITLE
Being able to outsource the mail parsing

### DIFF
--- a/imap.js
+++ b/imap.js
@@ -132,12 +132,16 @@ ImapConnection.prototype.connect = function(loginCb) {
       if (!curReq._done) {
         self._state.curXferred += Buffer.byteLength(data, 'utf8');
         if (self._state.curXferred <= self._state.curExpected) {
-          if (curReq._msgtype === 'headers')
+          if (curReq._msgtype === 'headers'){
             // buffer headers since they're generally not large and are
             // processed anyway
             self._state.curData += data;
-          else
+            // emit the event anyway because we maybe want to delegate the
+            // mail parsing to another lib.
             curReq._msg.emit('data', data);
+          } else {
+            curReq._msg.emit('data', data);
+          }
           return;
         }
         var pos = Buffer.byteLength(data, 'utf8')-(self._state.curXferred-self._state.curExpected);


### PR DESCRIPTION
In order to parse the mail with mailparser lib (or another library) we need to emit the data event while parsing the header as well as the body.

In a more general order, it should be possible to just get the content without doing any interpretation on it. This way imap lib would just ensure the raw content is delivered and another library would parse any email, whatever the source.

I think just emitting the data event on header is non-intrusive and will keep compatibility. But I think that some functionalities should be remove from this library at term. 
