### PR TITLE
fix parsing of EXAMINE response

### DIFF
--- a/imap.js
+++ b/imap.js
@@ -257,11 +257,11 @@ ImapConnection.prototype.connect = function(loginCb) {
             self.emit('alert', result[1]);
           else if (self._state.status === STATES.BOXSELECTING) {
             var result;
-            if ((result = /^\[UIDVALIDITY (\d+)\]$/i.exec(data[2])) !== null)
+            if ((result = /^\[UIDVALIDITY (\d+)\].*/i.exec(data[2])) !== null)
               self._state.box.validity = result[1];
-            else if ((result = /^\[UIDNEXT (\d+)\]$/i.exec(data[2])) !== null)
+            else if ((result = /^\[UIDNEXT (\d+)\].*/i.exec(data[2])) !== null)
               self._state.box._uidnext = result[1];
-            else if ((result = /^\[PERMANENTFLAGS \((.*)\)\]$/i.exec(data[2])) !== null) {
+            else if ((result = /^\[PERMANENTFLAGS \((.*)\)\].*/i.exec(data[2])) !== null) {
               self._state.box.permFlags = result[1].split(' ');
               var idx;
               if ((idx = self._state.box.permFlags.indexOf('\\*')) > -1) {


### PR DESCRIPTION
Patch itself is trivial, fixes talking to implementations (Dovecot for example) that reply in this way:

```
* OK [UIDVALIDITY 1239821276] UIDs valid
* OK [UIDNEXT 25] Predicted next UID
```

---

When looking into this, I was wondering about one thing: the parsed value of UIDNEXT is put into undocumented _uidnext field on Box object, and not even used anywhere inside imap.js. Is this oversight? Or is the value too unreliable to expose? It was useful in my testing script, but I don't have much experience with imap internals...
