### PR TITLE
Small changes to regular expressions

### DIFF
--- a/imap.js
+++ b/imap.js
@@ -331,7 +331,7 @@ ImapConnection.prototype.connect = function(loginCb) {
         case 'LIST':
           var result;
           if (self.delim === null
-              && (result = /^\(\\No[sS]elect\) (.+?) ".*"$/.exec(data[2])))
+              && (result = /^\(\\No[sS]elect\) (.+?) .*$/.exec(data[2])))
             self.delim = (result[1] === 'NIL'
                           ? false : result[1].substring(1, result[1].length-1));
           else if (self.delim !== null) {


### PR DESCRIPTION
Exchange doesn't always put mailbox names between "".
