### PR TITLE
fixed: unlimited error loop

### DIFF
--- a/imap.js
+++ b/imap.js
@@ -1695,7 +1695,7 @@ function pipe(pair, socket) {
 
   function onerror(e) {
     if (cleartext._controlReleased)
-      cleartext.socket.emit('error', e);
+      cleartext.emit('error', e);
   }
 
   function onclose() {


### PR DESCRIPTION
so this code make error recurrung call and as the result stack overflow when come things wrong with connection lost connection or dns lookup failed

  var cleartext = pair.cleartext;
  cleartext.socket = socket;

  function onerror(e) {
    if (cleartext._controlReleased)
      cleartext.socket.emit('error', e);// in this line we call emit error event in recurring way. 
  }

  socket.on('error', onerror);// this code the same as cleartext.socket.on('error', onerror)
