### PR TITLE
Complete result of getBoxes()

### DIFF
--- a/imap.js
+++ b/imap.js
@@ -369,7 +369,9 @@ ImapConnection.prototype.connect = function(loginCb) {
               }
               box.parent = parent;
             }
-            curChildren[name] = box;
+            if ( ! curChildren[name] ) {
+              curChildren[name] = box;
+            }
           }
         break;
         default:
@@ -618,7 +620,7 @@ ImapConnection.prototype.renameBox = function(oldname, newname, cb) {
   if (this._state.status === STATES.BOXSELECTED
       && oldname === this._state.box.name && oldname !== 'INBOX')
     this._state.box._newName = oldname;
-    
+
   this._send('RENAME "' + escape(oldname) + '" "' + escape(newname) + '"', cb);
 };
 
@@ -1561,21 +1563,21 @@ function extend() {
     if (!obj || toString.call(obj) !== "[object Object]" || obj.nodeType
         || obj.setInterval)
       return false;
-    
+
     var has_own_constructor = hasOwnProperty.call(obj, "constructor");
     var has_is_prop_of_method = hasOwnProperty.call(obj.constructor.prototype,
                                                     "isPrototypeOf");
     // Not own constructor property must be Object
     if (obj.constructor && !has_own_constructor && !has_is_prop_of_method)
       return false;
-    
+
     // Own properties are enumerated firstly, so to speed up,
     // if last one is own, then all properties are own.
 
     var last_key;
     for (var key in obj)
       last_key = key;
-    
+
     return last_key === undefined || hasOwnProperty.call(obj, last_key);
   };
 
@@ -1642,7 +1644,7 @@ function bufferSplit(buf, str) {
     ret = [buf];
   else if (start < buf.length)
     ret.push(buf.slice(start));
-  
+
   return ret;
 };
 


### PR DESCRIPTION
When I run LIST on my IMAP server, I get something like this:

. LIST "" "*"
...
- LIST (\HasNoChildren) "." "INBOX.archiv.inbox2005"
- LIST (\HasNoChildren) "." "INBOX.archiv.inbox2006"
- LIST (\HasNoChildren) "." "INBOX.archiv.inbox2007"
- LIST (\HasNoChildren) "." "INBOX.archiv.inbox2009"
- LIST (\HasChildren) "." "INBOX.archiv"
  ...

The current implementation overwrites the "INBOX.archiv.inbox..."
boxes as soon as "INBOX.archiv" is processed.

This is a small fix to make sure that the previously processed
boxes are not overwritten.
