### PR TITLE
Regex update when LIST has extra flags along with Noselect

### DIFF
--- a/imap.js
+++ b/imap.js
@@ -336,7 +336,7 @@ ImapConnection.prototype.connect = function(loginCb) {
         case 'XLIST':
           var result;
           if (self.delim === null
-              && (result = /^\(\\No[sS]elect\) (.+?) .*$/.exec(data[2])))
+              && (result = /^\(\\No[sS]elect.*\) (.+?) .*$/.exec(data[2])))
             self.delim = (result[1] === 'NIL'
                           ? false : result[1].substring(1, result[1].length-1));
           else if (self.delim !== null) {


### PR DESCRIPTION
WIthout this fix, the LIST command returns no mailboxes if the root mailbox has the Noselect flag and additional flags.
