### PR TITLE
Parse disposition as documented in README.md.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/imap.js
+++ b/imap.js
@@ -1399,16 +1399,17 @@ function parseStructExtra(part, partLen, cur, next) {
   if (partLen > next) {
     // disposition
     // null or a special k/v list with these kinds of values:
-    // e.g.: ['Foo', null]
-    //       ['Foo', ['Bar', 'Baz']]
-    //       ['Foo', ['Bar', 'Baz', 'Bam', 'Pow']]
+    // e.g.: ['inline', null]
+    //       ['attachment', null]
+    //       ['inline', ['filename', 'foo.pdf']]
+    //       ['inline', ['Bar', 'Baz', 'Bam', 'Pow']]
     if (Array.isArray(cur[next])) {
-      part.disposition = {};
+      part.disposition = {type: cur[next][0], params: null};
       if (Array.isArray(cur[next][1])) {
+        var params = part.disposition.params = {};
         for (var i=0,len=cur[next][1].length; i<len; i+=2)
-          part.disposition[cur[next][1][i].toLowerCase()] = cur[next][1][i+1];
-      } else
-        part.disposition[cur[next][0]] = cur[next][1];
+          params[cur[next][1][i].toLowerCase()] = cur[next][1][i+1];
+      }
     } else
       part.disposition = cur[next];
     ++next;
@@ -1711,3 +1712,8 @@ function pipe(pair, socket) {
 
   return cleartext;
 }
+
+exports._testFuncs = {
+  parseBodyStructure: parseBodyStructure,
+  parseExpr: parseExpr,
+};

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "author": "Brian White <mscdex@mscdex.net>",
   "description": "An IMAP module for node.js that makes communicating with IMAP servers easy",
   "main": "./imap",
+  "devDependencies": { "nodeunit": "*" },
+  "scripts": {
+    "test": "nodeunit test/"
+  },
   "engines": { "node" : ">=0.4.0" },
   "keywords": [ "imap", "mail", "email", "reader", "client" ],
   "licenses": [ { "type": "MIT", "url": "http://github.com/mscdex/node-imap/raw/master/LICENSE" } ],

--- a/test/bodystructure.js
+++ b/test/bodystructure.js
@@ -1,0 +1,33 @@
+var imap = require('../imap'), util = require('util'),
+    parseBodyStructure = imap._testFuncs.parseBodyStructure,
+    parseExpr = imap._testFuncs.parseExpr;
+
+var DEBUG = false;
+
+function maybeDebugStructure(bodystructureString) {
+  var expr = parseExpr(bodystructureString);
+  if (DEBUG) {
+    console.log("expr:");
+    console.log(util.inspect(expr, false, 6));
+  }
+  var structure = parseBodyStructure(expr[0]);
+  if (DEBUG) {
+    console.log("structure:");
+    console.log(util.inspect(structure, false, 6));
+  }
+  return structure;
+}
+
+exports["Disposition"] = {
+  "Multipart Inline PDF (Dovecot, Apple Mail)": function(test) {
+    var BODYSTRUCTURE = '(("text" "plain" ("charset" "us-ascii") NIL NIL "quoted-printable" 370 19 NIL NIL NIL NIL)("application" "pdf" ("x-mac-hide-extension" "yes" "x-unix-mode" "0644" "name" "filename.pdf") NIL NIL "base64" 2067794 NIL ("inline" ("filename" "filename.pdf")) NIL NIL) "mixed" ("boundary" "Apple-Mail=_801866EE-56A0-4F30-8DB3-2496094971D1") NIL NIL NIL)';
+
+    var structure = maybeDebugStructure(BODYSTRUCTURE), part;
+
+    part = structure[2][0];
+    test.equal(part.partID, 2);
+    test.equal(part.disposition.type, 'inline');
+    test.equal(part.disposition.params.filename, 'filename.pdf');
+    test.done();
+  },
+};


### PR DESCRIPTION
Without this patch, disposition is just a dictionary of parameters and the
disposition "type" is lost.

A nodeunit test is included which can be run via "npm test".  .gitignore is
added to ignore the node_modules/ directory when present because of
"npm install nodeunit".
