### PR TITLE
Allow STATUS command to be sent without having to wait for server response

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -632,7 +632,10 @@ ImapConnection.prototype.status = function(boxName, cb) {
   cmd += utils.escape(boxName);
   cmd += '" (MESSAGES RECENT UIDVALIDITY)';
 
-  this._send(cmd, cb);
+  var lastRequest = this._state.requests[this._state.requests.length - 1];
+  var isBatch = lastRequest && (lastRequest.isBatch
+    || (lastRequest.command.indexOf('STATUS ') === 0));
+  this._send(cmd, cb, false, isBatch);
 };
 
 ImapConnection.prototype.removeDeleted = function(cb) {
@@ -1101,15 +1104,20 @@ ImapConnection.prototype._noop = function() {
     this._send('NOOP');
 };
 
-ImapConnection.prototype._send = function(cmdstr, cb, bypass) {
+ImapConnection.prototype._send = function(cmdstr, cb, bypass, isBatch) {
+  var _state = this._state;
   if (cmdstr !== undefined && !bypass)
-    this._state.requests.push({ command: cmdstr, callback: cb, args: [] });
+    this._state.requests.push({ command: cmdstr, callback: cb, args: [],
+      isBatch: isBatch });
   if (this._state.ext.idle.state === IDLE_WAIT)
     return;
   if ((cmdstr === undefined && this._state.requests.length) ||
       this._state.requests.length === 1 || bypass) {
+    if(!bypass && this._state.requests[0].isBatch) // The batch is already sent!
+      return;
     var prefix = '', cmd = (bypass ? cmdstr : this._state.requests[0].command);
     clearTimeout(this._state.tmrKeepalive);
+
     if (this._state.ext.idle.state === IDLE_READY && cmd !== 'DONE')
       return this._send('DONE', undefined, true);
     else if (cmd === 'IDLE') {
@@ -1118,12 +1126,23 @@ ImapConnection.prototype._send = function(cmdstr, cb, bypass) {
       prefix = 'IDLE ';
       this._state.ext.idle.state = IDLE_WAIT;
     }
-    if (cmd !== 'IDLE' && cmd !== 'DONE')
-      prefix = 'A' + ++this._state.curId + ' ';
-    this._state.conn.cleartext.write(prefix);
-    this._state.conn.cleartext.write(cmd);
-    this._state.conn.cleartext.write(CRLF);
-    this.debug&&this.debug('\nCLIENT: ' + prefix + cmd + '\n');
+
+    var cmds = [cmd];
+    // add all subsequent calls those were marked as batch to command list
+    for(var i = 1; i < this._state.requests.length
+      && this._state.requests[i].isBatch; i++) {
+      cmds.push(this._state.requests[i].command);
+    }
+
+    var self = this;
+    cmds.forEach(function(cmd) {
+      if (cmd !== 'IDLE' && cmd !== 'DONE')
+        prefix = 'A' + ++self._state.curId + ' ';
+      self._state.conn.cleartext.write(prefix);
+      self._state.conn.cleartext.write(cmd);
+      self._state.conn.cleartext.write(CRLF);
+      self.debug&&self.debug('\nCLIENT: ' + prefix + cmd + '\n');
+    });
   }
 };
 


### PR DESCRIPTION
According to issues #73, I can call multiple status() commands concurrently and get correct results. However, each STATUS command will be sent after the previous command gets complete response from the server. This makes calling them concurrently equivalent to calling them one after another inside each previous status() command's callback. So it takes N round trips for N concurrent status() command calls.

This commit tries to allow STATUS command to be sent to the server without having to wait for server response. I have added a flag for each request specifying that it can be sent to the server immediately.

I'm not sure whether it will break anything else, or there may be a simpler and more elegant solution.
