### PR TITLE
Fix missing message structure in fetch result

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -577,8 +577,8 @@ ImapConnection.prototype.connect = function(loginCb) {
   });
 
   this._state.conn.connect(this._options.port, this._options.host);
-  this._state.tmrConn = setTimeout(this._fnTmrConn.bind(this),
-                                   this._options.connTimeout, loginCb);
+  this._state.tmrConn = setTimeout(this._fnTmrConn.bind(this, loginCb),
+                                   this._options.connTimeout);
 };
 
 ImapConnection.prototype.isAuthenticated = function() {


### PR DESCRIPTION
Added BODYSTRUCTURE back to FETCH request. Seems like it was removed in 7efda6cb9e5b73847839f49ef4a4b3f18ae2e76a.
