### PR TITLE
Add index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/imap.js');


### PR DESCRIPTION
Allows node-imap to be required using `require('imap');`
