### PR TITLE
Increment attribute value index after it is parsed when parsing response of STATUS

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -411,13 +411,13 @@ ImapConnection.prototype.connect = function(loginCb) {
               for (var i=0,len=m.attributes.length; i<len; ++i) {
                 switch (m.attributes[i].toUpperCase()) {
                   case 'RECENT':
-                    ret.messages.new = parseInt(m.attributes[i + 1], 10);
+                    ret.messages.new = parseInt(m.attributes[++i], 10);
                   break;
                   case 'MESSAGES':
-                    ret.messages.total = parseInt(m.attributes[i + 1], 10);
+                    ret.messages.total = parseInt(m.attributes[++i], 10);
                   break;
                   case 'UIDVALIDITY':
-                    ret.uidvalidity = parseInt(m.attributes[i + 1], 10);
+                    ret.uidvalidity = parseInt(m.attributes[++i], 10);
                   break;
                 }
               }


### PR DESCRIPTION
When parsing response of STATUS, increment attribute value index after it is parsed to prevent calling toUpperCase() on integer value.
