### PR TITLE
Fix typo and update readme for delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ ImapConnection Properties
 
 * **capabilities** - <_array_> - Contains the IMAP capabilities of the server.
 
-* **delim** - <_string_> - The (top-level) mailbox hierarchy delimiter. If the server does not support mailbox hierarchies and only a flat list, this value will be `false`.
+* **delimiter** - <_string_> - The (top-level) mailbox hierarchy delimiter. If the server does not support mailbox hierarchies and only a flat list, this value will be `false`.
 
 * **namespaces** - <_object_> - Contains information about each namespace type (if supported by the server) with the following properties:
 
@@ -316,7 +316,7 @@ ImapConnection Properties
 
 ```javascript
   { prefix: '' // A string containing the prefix to use to access mailboxes in this namespace
-  , delim: '/' // A string containing the hierarchy delimiter for this namespace, or boolean false
+  , delimiter: '/' // A string containing the hierarchy delimiter for this namespace, or boolean false
               //  for a flat namespace with no hierarchy
   , extensions: [ // An array of namespace extensions supported by this namespace, or null if none
                   // are specified
@@ -372,54 +372,54 @@ ImapConnection Functions
   { INBOX: // mailbox name
      { attribs: [] // mailbox attributes. An attribute of 'NOSELECT' indicates the mailbox cannot
                    // be opened
-     , delim: '/' // hierarchy delimiter for accessing this mailbox's direct children.
+     , delimiter: '/' // hierarchy delimiter for accessing this mailbox's direct children.
      , children: null // an object containing another structure similar in format to this top level,
                       // otherwise null if no children
      , parent: null // pointer to parent mailbox, null if at the top level
      }
   , Work:
      { attribs: []
-     , delim: '/'
+     , delimiter: '/'
      , children: null
      , parent: null
      }
   , '[Gmail]':
      { attribs: [ 'NOSELECT' ]
-     , delim: '/'
+     , delimiter: '/'
      , children:
         { 'All Mail':
            { attribs: []
-           , delim: '/'
+           , delimiter: '/'
            , children: null
            , parent: [Circular]
            }
         , Drafts:
            { attribs: []
-           , delim: '/'
+           , delimiter: '/'
            , children: null
            , parent: [Circular]
            }
         , 'Sent Mail':
            { attribs: []
-           , delim: '/'
+           , delimiter: '/'
            , children: null
            , parent: [Circular]
            }
         , Spam:
            { attribs: []
-           , delim: '/'
+           , delimiter: '/'
            , children: null
            , parent: [Circular]
            }
         , Starred:
            { attribs: []
-           , delim: '/'
+           , delimiter: '/'
            , children: null
            , parent: [Circular]
            }
         , Trash:
            { attribs: []
-           , delim: '/'
+           , delimiter: '/'
            , children: null
            , parent: [Circular]
            }

--- a/lib/imap.js
+++ b/lib/imap.js
@@ -80,7 +80,7 @@ function ImapConnection (options) {
     this.debug = this._options.debug;
   else
     this.debug = false;
-  this.delimeter = undefined;
+  this.delimiter = undefined;
   this.namespaces = { personal: [], other: [], shared: [] };
   this.capabilities = [];
 };
@@ -355,8 +355,8 @@ ImapConnection.prototype.connect = function(loginCb) {
             m.delimiter = parsers.convStr(m.delimiter, ondata.literals);
             m.mailbox = parsers.convStr(m.mailbox, ondata.literals);
             var result;
-            if (self.delimeter === undefined)
-              self.delimeter = parsers.convStr(m.delimiter, ondata.literals);
+            if (self.delimiter === undefined)
+              self.delimiter = parsers.convStr(m.delimiter, ondata.literals);
             else {
               if (requests[0].cbargs.length === 0)
                 requests[0].cbargs.push({});
@@ -364,15 +364,15 @@ ImapConnection.prototype.connect = function(loginCb) {
                     attribs: m.flags.map(function(attr) {
                                return attr.substr(1);
                              }),
-                    delimeter: m.delimiter,
+                    delimiter: m.delimiter,
                     children: null,
                     parent: null
                   },
                   name = m.mailbox,
                   curChildren = requests[0].cbargs[0];
 
-              if (box.delimeter) {
-                var path = name.split(box.delimeter).filter(utils.isNotEmpty),
+              if (box.delimiter) {
+                var path = name.split(box.delimiter).filter(utils.isNotEmpty),
                     parent = null;
                 name = path.pop();
                 for (var i=0,len=path.length; i<len; i++) {
@@ -1116,7 +1116,7 @@ ImapConnection.prototype._reset = function() {
   this._state.ext.idle.timeWaited = 0;
 
   this.namespaces = { personal: [], other: [], shared: [] };
-  this.delimeter = null;
+  this.delimiter = undefined;
   this.capabilities = [];
   this._resetBox();
 };

--- a/lib/imap.parsers.js
+++ b/lib/imap.parsers.js
@@ -26,7 +26,7 @@ exports.parseNamespaces = function(str, literals) {
     for (var i=0,len=result.length; i<len; ++i) {
       var val = {
         prefix: result[i][0],
-        delimeter: result[i][1]
+        delimiter: result[i][1]
       };
       if (result[i].length > 2) {
         // extension data


### PR DESCRIPTION
Fix typo in code (delimeter to delimiter) and update readme to use delimiter instead of delim.
