### PR TITLE
Fix buffer is not sliced when bytes remaining are less than bytes expected

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -160,16 +160,16 @@ ImapConnection.prototype.connect = function(loginCb) {
   });
 
   function read(b) {
-    var blen = b.length;
+    var blen = b.length, origPos = b.p;
     if (ondata.expect <= (blen - b.p)) {
-      var left = ondata.expect, origPos = b.p;
+      var left = ondata.expect;
       ondata.expect = 0;
       b.p += left;
       return b.slice(origPos, origPos + left);
     } else {
       ondata.expect -= (blen - b.p);
       b.p = blen;
-      return b;
+      return origPos > 0 ? b.slice(origPos) : b;
     }
   }
 


### PR DESCRIPTION
This pull request fixes issue #92. Please review it before merge since I'm not sure it will break anything else.

Thanks.
