### PR TITLE
BUG in current imap.utilities.line function

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -578,7 +578,7 @@ ImapConnection.prototype.connect = function(loginCb) {
       }
 
       var recentCmd = requests[0].cmdstr;
-      requests.shift();
+      self._completeRequest();
       if (requests.length === 0 && recentCmd !== 'LOGOUT') {
         if (state.status === STATES.BOXSELECTED && self._serverSupports('IDLE')) {
           // According to RFC 2177, we should re-IDLE at least every 29
@@ -620,6 +620,11 @@ ImapConnection.prototype.connect = function(loginCb) {
   state.conn.connect(this._options.port, this._options.host);
   state.tmrConn = setTimeout(this._fnTmrConn.bind(this, loginCb),
                                    this._options.connTimeout);
+};
+
+ImapConnection.prototype._completeRequest = function() {
+    this._state.requests.shift();
+    this._state.parser = null;
 };
 
 ImapConnection.prototype.isAuthenticated = function() {


### PR DESCRIPTION
Serious issue when downloading messages concurrently across multiple accounts.  State stored on line function is overwritten by other connections
