### PR TITLE
Fix invalid part id for message/rfc822 attachment

### DIFF
--- a/lib/imap.parsers.js
+++ b/lib/imap.parsers.js
@@ -178,9 +178,9 @@ exports.parseBodyStructure = function(cur, literals, prefix, partID) {
         ++next;
 
         // body
-        if (partLen > next && Array.isArray(cur[next])) {
+        if (partLen > next && Array.isArray(cur[next]))
           part.body = exports.parseBodyStructure(cur[next], literals, prefix, 1);
-        } else
+        else
           part.body = null;
         ++next;
       }


### PR DESCRIPTION
This commit fix invalid part id of a part inside a message/rfc822 attachment structure.
