### PR TITLE
Allow communication with an IMAP server proxy program

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -41,7 +41,9 @@ function ImapConnection (options) {
     port: 143,
     secure: false,
     connTimeout: 10000, // connection timeout in msecs
-    debug: false
+    debug: false,
+    proxy_program: false,
+    proxy_program_args: [],
   };
   this._state = {
     status: STATES.NOCONNECT,
@@ -92,6 +94,57 @@ function ImapConnection (options) {
   this.capabilities = [];
 }
 
+function ImapProxy(program, args) {
+  if (!(this instanceof ImapProxy))
+    return new ImapProxy(program, args);
+
+  EventEmitter.call(this);
+
+  this._program = program;
+  this._args = args;
+}
+
+inherits(ImapProxy, EventEmitter);
+
+ImapProxy.prototype.start = function() {
+  var self = this;
+  var sp = require('child_process').spawn(this._program, this._args,
+                                          {stdio: ['pipe', 'pipe', process.stderr]});
+  sp.stdout.on('data', function(data) {
+    self.emit('data', data);
+  });
+  sp.on('exit', function(code) {
+    if(code != 0) {
+      var error = new Error("Subprocess "+ self._program + self._args +  " exited with non-zero status " + code);
+      self.emit('error', error)
+      self.emit('close', error);
+    } else {
+      self.emit('close');
+    }
+  });
+  this._process = sp;
+}
+
+ImapProxy.prototype.write = function(string, encoding) {
+  return this._process.stdin.write(new Buffer(string, encoding));
+}
+
+ImapProxy.prototype.destroy = function() {
+  this._process.kill();
+}
+
+ImapProxy.prototype.end = function() {
+  this._process.kill();
+}
+
+ImapProxy.prototype.connect = function(host, port) {
+  this.emit('connect');
+  this.once('data', function(data) {
+    this.emit('data', data);
+    this.emit('ready');
+  });
+}
+
 inherits(ImapConnection, EventEmitter);
 exports.ImapConnection = ImapConnection;
 
@@ -106,15 +159,25 @@ ImapConnection.prototype.connect = function(loginCb) {
   state.conn = new Socket();
   state.conn.setKeepAlive(true);
 
-  if (this._options.secure) {
-    // TODO: support STARTTLS
-    state.conn.cleartext = utils.setSecure(state.conn);
-    state.conn.on('secure', function() {
-      self.debug&&self.debug('[connection] Secure connection made.');
-    });
-  } else
-    state.conn.cleartext = state.conn;
+  if (!this._options.proxy_program) {
+    if (this._options.secure) {
+      // TODO: support STARTTLS
+      state.conn.cleartext = utils.setSecure(state.conn);
+      state.conn.on('secure', function() {
+        self.debug&&self.debug('[connection] Secure connection made.');
+      });
+    } else
+      state.conn.cleartext = state.conn;
 
+    state.conn.on('end', function() {
+      self.debug&&self.debug('[connection] FIN packet received. Disconnecting...');
+      self.emit('end');
+    });
+  } else {
+    state.conn = new ImapProxy(this._options.proxy_program, this._options.proxy_program_args);
+    state.conn.cleartext = state.conn;
+    state.conn.start();
+  }
   state.conn.on('connect', function() {
     clearTimeout(state.tmrConn);
     self.debug&&self.debug('[connection] Connected to host.');
@@ -122,10 +185,6 @@ ImapConnection.prototype.connect = function(loginCb) {
     state.status = STATES.NOAUTH;
   });
 
-  state.conn.on('end', function() {
-    self.debug&&self.debug('[connection] FIN packet received. Disconnecting...');
-    self.emit('end');
-  });
 
   function errorHandler(err) {
     clearTimeout(state.tmrConn);
@@ -226,7 +285,7 @@ ImapConnection.prototype.connect = function(loginCb) {
       indata.expect = (m ? parseInt(m[2], 10) : -1);
       if (indata.expect > -1) {
         if ((m = /\* (\d+) FETCH/i.exec(indata.line))
-            && /^BODY\[/i.test(litType)) {
+            && /^BODY\[/i.test(litType)) {     // / (placate emacs)
           var msg = new ImapMessage();
           msg.seqno = parseInt(m[1], 10);
           requests[0]._msg = msg;
@@ -617,9 +676,9 @@ ImapConnection.prototype.connect = function(loginCb) {
 
   state.conn.cleartext.on('data', ondata);
 
-  state.conn.connect(this._options.port, this._options.host);
   state.tmrConn = setTimeout(this._fnTmrConn.bind(this, loginCb),
                                    this._options.connTimeout);
+  state.conn.connect(this._options.port, this._options.host);
 };
 
 ImapConnection.prototype.isAuthenticated = function() {


### PR DESCRIPTION
This change lets node-imap start a proxy program whose stout and stdin
behave like an IMAP server would. For example, it can now connect to a
locally-running docecot instance (http://wiki.dovecot.org/PreAuth).

This also allows connecting to imap servers running behind spiped
tunnels and other non-standard topologies.

To make a preauthed dovecot work, this change also needs this pull request: https://github.com/mscdex/node-imap/pull/109 but the two pulls are pretty much independent. I'm much less sure about this one, and can totally understand if you're not comfortable with it at this stage. I am absolutely open to suggestions for reworking it to better fit in.
