### PR TITLE
Xoauth2 gmail

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -566,8 +566,7 @@ ImapConnection.prototype.connect = function(loginCb) {
         var args = requests[0].cbargs,
             cmdstr = requests[0].cmdstr;
         if (line[0] === '+') {
-          if (requests[0].cmd !== 'APPEND' && requests[0].cmd !== 'AUTHENTICATE') {
-            console.log(requests[0].cmd, "\n", line, requests[0].callback.toString());
+          if (requests[0].cmd !== 'APPEND') {
             err = new Error('Unexpected continuation');
             err.type = 'continuation';
             err.request = cmdstr;


### PR DESCRIPTION
Gmail sends back a response to "AUTHENTICATE XOAUTH2 ..." that is base64 encoded. It needs to be base64 decoded; otherwise, an Error "Unexpected continuation" is generated.
