### PR TITLE
Make useParser optional

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -882,6 +882,7 @@ ImapConnection.prototype._fetch = function(which, uids, options) {
   utils.validateUIDList(uids);
 
   var opts = {
+    useParser: true,
     markSeen: false,
     request: {
       struct: true,
@@ -920,7 +921,7 @@ ImapConnection.prototype._fetch = function(which, uids, options) {
       // fetches (all) headers only
       toFetch = 'HEADER';
     }
-    useParser = true;
+    useParser = opts.useParser;
   } else if (opts.request.body === true) {
     // fetches the whole entire message text (minus the headers), including
     // all message parts


### PR DESCRIPTION
I found the need to get the headers raw without any parsing (so my own
parser could be used). This makes using the default parser optional.
When set to false the headers are obtained through the 'data' event.
