### PR TITLE
Catch 'error' events from SSL connection

### DIFF
--- a/lib/imap.utilities.js
+++ b/lib/imap.utilities.js
@@ -32,6 +32,9 @@ exports.setSecure = function(tcpSocket) {
     process.nextTick(function() { cleartext.socket.emit('secure'); });
   });
 
+  pair.on('error', onerror);
+  pair.on('close', onclose);
+
   cleartext._controlReleased = true;
   return cleartext;
 };


### PR DESCRIPTION
If you try to connect using 'secure:true' to a non-ssl port like 143, you get an error event.  This catches that and other SSL connection errors and passes them up where they can be seen instead of crashing the process with an unhandled 'error' event.
