### PR TITLE
Mailbox name gets convert to number

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -428,7 +428,7 @@ ImapConnection.prototype.connect = function(loginCb) {
             // m.mailbox = mailbox name (string)
             m.flags = (m.flags ? m.flags.toUpperCase().split(' ') : []);
             m.delimiter = parsers.convStr(m.delimiter, indata.literals);
-            m.mailbox = parsers.convStr(m.mailbox, indata.literals);
+            m.mailbox = '' + parsers.convStr(m.mailbox, indata.literals);
             if (self.delimiter === undefined)
               self.delimiter = parsers.convStr(m.delimiter, indata.literals);
             else {
@@ -475,7 +475,7 @@ ImapConnection.prototype.connect = function(loginCb) {
           case 'STATUS':
             // m.mailbox = mailbox name (string)
             // m.attributes = expression list (k=>v pairs) of mailbox attributes
-            m.mailbox = parsers.convStr(m.mailbox, indata.literals);
+            m.mailbox = '' + parsers.convStr(m.mailbox, indata.literals);
             var ret = {
               name: m.mailbox,
               uidvalidity: 0,


### PR DESCRIPTION
Mailbox name that passes this RegExp /^\d+$/ gets convert to number by convStr() function. Calling split() on the mailbox name cause node to crash.
