### PR TITLE
Fetch BODY.PEEK when markSeen option is false and ignore ".PEEK" in fetcher key

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -927,7 +927,7 @@ ImapConnection.prototype._fetch = function(which, uids, options, what, cb) {
   utils.validateUIDList(uids);
 
   var toFetch = '', prefix, extensions, self = this,
-      parse = true, headers, key, stream,
+      parse = true, headers, key, stream, fKey,
       fetchers = {};
 
   if (typeof what === 'function') {
@@ -935,7 +935,7 @@ ImapConnection.prototype._fetch = function(which, uids, options, what, cb) {
     what = options;
     options = {};
   }
-  prefix = (options.markSeen ? ' BODY.PEEK[' : ' BODY[');
+  prefix = (options.markSeen ? ' BODY[' : ' BODY.PEEK[');
   if (!Array.isArray(what))
     what = [what];
   for (var i = 0, wp, pprefix, len = what.length; i < len; ++i) {
@@ -963,14 +963,16 @@ ImapConnection.prototype._fetch = function(which, uids, options, what, cb) {
       if (wp.id !== undefined)
         key += wp.id;
       key += ']';
-      if (!fetchers[key]) {
-        fetchers[key] = [new ImapFetch()];
+      fKey = options.markSeen ? key : key.replace('.PEEK', '');
+      if (!fetchers[fKey]) {
+        fetchers[fKey] = [new ImapFetch()];
         toFetch += ' ';
         toFetch += key;
       }
       if (typeof wp.cb === 'function')
-        wp.cb(fetchers[key][0]);
+        wp.cb(fetchers[fKey][0]);
       key = undefined;
+      fKey = undefined;
     } else if (wp.headers || wp.headersNot || wp.body) {
       pprefix = prefix;
       if (wp.id !== undefined) {
@@ -1047,18 +1049,20 @@ ImapConnection.prototype._fetch = function(which, uids, options, what, cb) {
         }
       }
       if (key) {
+        fKey = options.markSeen ? key : key.replace('.PEEK', '');
         stream = new ImapFetch();
         if (parse)
           stream._parse = true;
-        if (!fetchers[key]) {
-          fetchers[key] = [stream];
+        if (!fetchers[fKey]) {
+          fetchers[fKey] = [stream];
           toFetch += ' ';
           toFetch += key;
         } else
-          fetchers[key].push(stream);
+          fetchers[fKey].push(stream);
         if (typeof wp.cb === 'function')
           wp.cb(stream);
         key = undefined;
+        fKey = undefined;
       }
       if (wp.body) {
         key = pprefix;
@@ -1079,13 +1083,14 @@ ImapConnection.prototype._fetch = function(which, uids, options, what, cb) {
           throw new Error('Invalid `body` value: ' + wp.body);
 
         key = key.trim();
+        fKey = options.markSeen ? key : key.replace('.PEEK', '');
         if (!stream)
           stream = new ImapFetch();
-        if (!fetchers[key]) {
-          fetchers[key] = [stream];
+        if (!fetchers[fKey]) {
+          fetchers[fKey] = [stream];
           toFetch += ' ' + key;
         } else
-          fetchers[key].push(stream);
+          fetchers[fKey].push(stream);
         if (!wp.headers && !wp.headersNot && typeof wp.cb === 'function')
           wp.cb(stream);
         stream = undefined;


### PR DESCRIPTION
It seems like prefix for fetching message with markSeen option has been switched.

Either markSeen is true or false, IMAP response for body fetch doesn't contain ".PEEK". So we should ignore ".PEEK" in fetcher key.
