### PR TITLE
Don't encode mailbox name when add new mailbox

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -785,7 +785,7 @@ ImapConnection.prototype.getBoxes = function(namespace, cb) {
 };
 
 ImapConnection.prototype.addBox = function(name, cb) {
-  this._send('CREATE "' + utils.escape(utf7.encode(''+name)) + '"', cb);
+  this._send('CREATE "' + utils.escape(''+name) + '"', cb);
 };
 
 ImapConnection.prototype.delBox = function(name, cb) {


### PR DESCRIPTION
Don't encode mailbox name when add new mailbox. Easiest and laziest way to fix #143.
