### PR TITLE
Header parsing fails for headers with no value.

### DIFF
--- a/lib/imap.parsers.js
+++ b/lib/imap.parsers.js
@@ -2,6 +2,7 @@ var utils = require('./imap.utilities');
 
 var reCRLF = /\r\n/g,
     reHdr = /^([^:]+):\s(.+)?$/,
+    reHdrOnly = /^([^:]+):$/,
     reHdrFold = /^\s+(.+)$/;
 
 exports.convStr = function(str, literals) {
@@ -32,8 +33,8 @@ exports.parseHeaders = function(str) {
       m = reHdrFold.exec(lines[i]);
       headers[h][headers[h].length - 1] += m[1];
     } else {
-      m = reHdr.exec(lines[i]);
-      h = m[1].toLowerCase();
+      m = reHdr.exec(lines[i]) || reHdrOnly.exec(lines[i]);
+      h = m[1] ? m[1].toLowerCase() : '';
       if (m[2]) {
         if (headers[h] === undefined)
           headers[h] = [m[2]];


### PR DESCRIPTION
The following header breaks the header parsing:

```
X-Face:
 H@&[wkk?l:Zx:8i_5b....
```

There is no whitespace after the colon, so it doesn't match the header
regex. This causes an error since there is no toLowerCase method on
m[1], which is undefined.

Added a second regex which only gets executed in the rare cases that
reHdr fails. Should not impact any mail parsing that was working
previously not should it impact the performance.
