### PR TITLE
Change `EventEmitter` to `Stream` for ".pipe()" and other Stream goodies

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -3,7 +3,7 @@ var assert = require('assert'),
     inspect = require('util').inspect,
     inherits = require('util').inherits,
     Socket = require('net').Socket,
-    EventEmitter = require('events').EventEmitter,
+    Stream = require('stream').Stream,
     utf7 = require('utf7').imap,
     // customized copy of XRegExp to deal with multiple variables of the same
     // name
@@ -38,7 +38,7 @@ var IDLE_NONE = 1,
 function ImapConnection(options) {
   if (!(this instanceof ImapConnection))
     return new ImapConnection(options);
-  EventEmitter.call(this);
+  Stream.call(this);
 
   this._options = {
     username: options.username || options.user || '',
@@ -105,7 +105,7 @@ function ImapConnection(options) {
   this.authenticated = false;
 }
 
-inherits(ImapConnection, EventEmitter);
+inherits(ImapConnection, Stream);
 module.exports = ImapConnection;
 module.exports.ImapConnection = ImapConnection;
 
@@ -1498,9 +1498,9 @@ function ImapMessage() {
   this.structure = undefined;
   this.size = undefined;
 }
-inherits(ImapMessage, EventEmitter);
+inherits(ImapMessage, Stream);
 
 function ImapFetch() {
   this._parse = false;
 }
-inherits(ImapFetch, EventEmitter);
+inherits(ImapFetch, Stream);


### PR DESCRIPTION
As explained in [here](https://github.com/aredridel/node-smtp/pull/5) it becomes handy to have a Stream inherited message. The pipe method can really come handy in much ways.

For example I used it in combination with [mailparser](https://github.com/andris9/mailparser) module like this:

``` javascript
//...
imap.fetch(results, {
  headers: {
    parse: false
  },
  body: true,
  cb: function(fetch) {
    fetch.on("message", function(message) {
      var parser = new mailparser.MailParser;

      parser.on("headers", function(headers) {
        return console.log("Message Headers:", headers.received);
      });

      parser.on("end", function(mail) {
        return console.log("Mail:", mail);
      });

      message.pipe(parser);
    });
  }
}, function(err) {
  imap.logout();
});

//...
```
