### PR TITLE
Allow custom TLS options

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -47,7 +47,9 @@ function ImapConnection(options) {
     password: options.password || '',
     host: options.host || 'localhost',
     port: options.port || 143,
-    secure: options.secure || false,
+    secure: options.secure === true ? { // secure = true means default behavior
+      rejectUnauthorized: false // Force pre-node-0.9.2 behavior
+    } : (options.secure || false),
     connTimeout: options.connTimeout || 10000, // connection timeout in msecs
     xoauth: options.xoauth,
     xoauth2: options.xoauth2
@@ -124,10 +126,15 @@ ImapConnection.prototype.connect = function(loginCb) {
   socket.setTimeout(0);
 
   if (this._options.secure) {
+    var tlsOptions = {};
+    for (var k in this._options.secure) {
+      tlsOptions[k] = this._options.secure[k];
+    }
+    tlsOptions.socket = state.conn;
     if (process.version.indexOf('v0.6.') > -1)
-      socket = tls.connect(null, { socket: state.conn }, onconnect);
+      socket = tls.connect(null, tlsOptions, onconnect);
     else
-      socket = tls.connect({ socket: state.conn }, onconnect);
+      socket = tls.connect(tlsOptions, onconnect);
   } else
     state.conn.once('connect', onconnect);
 


### PR DESCRIPTION
- Option `secure` can now be a hash of options to be passed to `tls.connect`
- If `secure` is simply set to `true`, default TLS option `rejectUnauthorized` is set to `false` to force pre-0.9.2 behavior (fixing #181)
