### PR TITLE
fix for append with empty flags array

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -845,7 +845,8 @@ ImapConnection.prototype.append = function(data, options, cb) {
   if (options.flags) {
     if (!Array.isArray(options.flags))
       options.flags = [options.flags];
-    cmd += " (\\" + options.flags.join(' \\') + ")";
+    if (options.flags.length > 0)
+      cmd += " (\\" + options.flags.join(' \\') + ")";
   }
   if (options.date) {
     if (!isDate(options.date))


### PR DESCRIPTION
Calling append with options set to:

```
options: {"flags":[],"date":"2011-10-17T14:36:48.000Z"}
```

will cause an error:

```
Error removing attachments during undefined: { [Error: Invalid Arguments: Unable to parse flag \]
  level: 'protocol',
  code: undefined,
  request: 'APPEND "myfolder" (\\) "17-Oct-2011 07:36:48 --700" {2538}' }
```

The attached pull request fixes this.
