### PR TITLE
Support QUOTA extension

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -924,7 +924,7 @@ ImapConnection.prototype.renameBox = function(oldname, newname, cb) {
 ImapConnection.prototype.setQuota = function(quotaroot, quota, cb) {
   if (!this.serverSupports('QUOTA'))
     return cb(new Error('Quota is not supported on the server'));
-  var cmd = 'SETQUOTA "' + utils.escape(utf7.encode(''+name)) + '" ('
+  var cmd = 'SETQUOTA "' + utils.escape(utf7.encode(''+quotaroot)) + '" ('
   cmd += Object.keys(quota).map(function(resource) {
            return resource + ' ' + quota[resource];
          }).join(' ');


### PR DESCRIPTION
This pull request adds 3 methods for QUOTA extension. Are you okay with the method signatures below?

**Method signatures:**
(common parameters: `quotaroot` = quota root name, `name` = box name)
- setQuota(quotaroot, quota, cb) - Sets quota to a quota root. `quota` = an object containing resource names and their limits as key-value pairs, e.g. { storage: 52428800, message: 1000 }. (I haven't tested this method yet since it requires some permissions.)
- getQuotaRoot(name, cb) - Gets quota roots of a mailbox. `cb` has 2 parameters: `err` and `quotaroots` which is an object mapping between each quota root name of the mailbox and usages/limits information of its resources. See example of `quotaroots` object below:

```
imap.getQuotaRoot('INBOX', cb);
quotaroots =
{
  INBOX: {
    storage: { // storage unit is KB
      usage: 229844,
      limit: 52428800
    }
  },
  'Another INBOX quota': {
    message: {
      usage: 100,
      limit: 1000
    }
  }
}
```
- getQuota(quotaroot, cb) - Gets quota information of a quota root. `cb` has 2 parameters: `err` and `quotaInfo` which is a usages/limits information of its resources.

```
imap.getQuota('Another INBOX quota', cb);
quotaInfo =
{
  message: {
    usage: 100,
    limit: 1000
  }
}
```
