### PR TITLE
Allow fetching of individual parts

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -1186,6 +1186,9 @@ ImapConnection.prototype._fetch = function(which, uids, options, what, cb) {
         key = pprefix;
         if (wp.body === true)
           key += 'TEXT]';
+        else if (wp.body === 'part') {
+            key = key.slice(1, -1) + ']';
+        }
         /*else if (typeof wp.body.start === 'number'
                    && typeof wp.body.length === 'number') {
           if (wp.body.start < 0)


### PR DESCRIPTION
Allow individual parts to be selected when specifying id / body combination; body = 'part' to override adding .TEXT] to the FETCH request.
