### PR TITLE
gm labels sometimes aren't strings

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -335,7 +335,7 @@ ImapConnection.prototype.connect = function(loginCb) {
             if (details['x-gm-labels'] !== undefined) {
               var labels = details['x-gm-labels'];
               for (var i=0, len=labels.length; i<len; ++i)
-                labels[i] = labels[i].replace(RE_ESCAPE, '\\');
+                labels[i] = ('' + labels[i]).replace(RE_ESCAPE, '\\')
             }
 
             if (isUnsolicited)


### PR DESCRIPTION
Simple type check on label to prevent errors like the one below...

2013-05-15T03:24:06.419Z - error: uncaughtException: stack=TypeError: Object 390 has no method 'replace'
    at ondata (/usr/local/mikey/mikeymail/node_modules/imap/lib/imap.js:338:39)
    at ondata (/usr/local/mikey/mikeymail/node_modules/imap/lib/imap.js:305:16)
    at ondata (/usr/local/mikey/mikeymail/node_modules/imap/lib/imap.js:632:16)
    at ondata (/usr/local/mikey/mikeymail/node_modules/imap/lib/imap.js:305:16)
    at ondata (/usr/local/mikey/mikeymail/node_modules/imap/lib/imap.js:632:16)
    at ondata (/usr/local/mikey/mikeymail/node_modules/imap/lib/imap.js:305:16)
    at ondata (/usr/local/mikey/mikeymail/node_modules/imap/lib/imap.js:632:16)
    at ondata (/usr/local/mikey/mikeymail/node_modules/imap/lib/imap.js:305:16)
    at ondata (/usr/local/mikey/mikeymail/node_modules/imap/lib/imap.js:632:16)
    at ondata (/usr/local/mikey/mikeymail/node_modules/imap/lib/imap.js:305:16), message=Object 390 has no method 'replace', stacktrace=
    at process.<anonymous> (/usr/local/mikey/serverCommon/lib/appInitUtils.js:19:11)
    at process.EventEmitter.emit (events.js:95:17)
    at process._fatalException (node.js:272:26)
