### PR TITLE
Prevents "Cannot read property 'cmd' of undefined"

### DIFF
--- a/lib/imap.js
+++ b/lib/imap.js
@@ -662,7 +662,7 @@ ImapConnection.prototype.connect = function(loginCb) {
           self._resetBox();
         }
       }
-      if (requests[0].cmd === 'RENAME') {
+      if (requests[0] && requests[0].cmd === 'RENAME') {
         if (state.box._newName) {
           state.box.name = state.box._newName;
           state.box._newName = undefined;


### PR DESCRIPTION
This is what I am using to prevent the crash when requests[0] is undefined, it of course does not fix the underlying issue but will at least prevent the process from exiting.
