### PR TITLE
Not detecting the end of an IDLE, fix for issue #241

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -128,8 +128,8 @@ Parser.prototype._parse = function(data) {
           }
         }
       } else {
-        this._buffer = '';
         this.emit('other', this._buffer);
+	    this._buffer = '';
       }
     }
   }


### PR DESCRIPTION
As the buffer was wiped before emitting the 'other' event, the
parser.on('other') event handler has no buffer data passed to it thus
can't detect the end of the IDLE and never calls the
self._processQueue() to get the stuff waiting in the queue to move.
