### PR TITLE
Fix unhandled error event on node v0.8

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -64,6 +64,8 @@ Parser.prototype.setStream = function(stream) {
       stream = wrapped;
     else
       stream = newStream;
+    // prevent unhandled error event
+    stream.once('error', function() {});
   }
   this._stream = stream;
 };


### PR DESCRIPTION
Hello again,

On node v0.8, connecting to a non-existent imap server produces an unhandled error even though I have already listened for the 'error' event on the connection. The error looks like this: 

```
events.js:66
        throw arguments[1]; // Unhandled 'error' event
                       ^
Error: getaddrinfo ENOENT
    at errnoException (dns.js:31:11)
    at Object.onanswer [as oncomplete] (dns.js:123:16)
```

I've tested with node v0.8.6 and 0.8.25 with the following code:

``` javascript
var Imap = require('imap');
var imap = new Imap({ host: 'localhostofnowhere', port: 143, user: 'test', password: 'test' });
imap.once('error', function(err) {
  console.error('error', err);
});
imap.once('end', function() { console.warn('end', arguments); });
imap.once('close', function(hadError) { console.warn('close', hadError); });
imap.connect();
```
