### PR TITLE
Handle undefined quotalist when set quota on some imap server (e.g. cyrus)

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -879,7 +879,7 @@ Connection.prototype.setQuota = function(quotaRoot, limits, cb) {
       if (err)
         return cb(err);
 
-      cb(err, quotalist[0]);
+      cb(err, quotalist ? quotalist[0] : limits);
     }
   );
 };


### PR DESCRIPTION
Some imap server doesn't return a QUOTA response after a SETQUOTA request, which makes the quotalist variable undefined. The following session is on cyrus imap server:

```
A1 getquota user/test
* QUOTA user/test (STORAGE 12 56320)
A1 OK Completed
A2 setquota user/test (STORAGE 56444)
A2 OK Completed
A3 getquota user/test
* QUOTA user/test (STORAGE 12 56444)
A3 OK Completed
```
