### PR TITLE
esearch should call _esearch and return data to callback. Removed space ...

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1097,10 +1097,8 @@ Connection.prototype._resUntagged = function(info) {
     this._caps = info.text.map(function(v) { return v.toUpperCase(); });
   else if (type === 'preauth')
     this.state = 'authenticated';
-  else if (type === 'sort' || type === 'thread')
-	this._curReq.cbargs.push(info.text);
-  else if (type === 'esearch')
-	this._curReq.cbargs.push(info.text);
+  else if (type === 'sort' || type === 'thread' || type === 'esearch')
+    this._curReq.cbargs.push(info.text);
   else if (type === 'search') {
     if (info.text.results !== undefined) {
       // CONDSTORE-modified search results


### PR DESCRIPTION
...in _esearch command and put it before encode, as query already has a space.  If using it without UTF8 encoding it gave an error because there are then two spaces before the actual query which is fixed.
