### PR TITLE
Handle short body section responded as quoted string

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -11,6 +11,7 @@ var CH_LF = 10,
     RE_INTEGER = /^\d+$/,
     RE_PRECEDING = /^(?:(?:\*|A\d+) )|\+ ?/,
     RE_BODYLITERAL = /BODY\[(.*)\] \{(\d+)\}$/i,
+    RE_BODYQUOTED = /BODY\[(.*)\] "((?:\\\\|\\"|[^\\"])*)"/i,
     RE_SEQNO = /^\* (\d+)/,
     RE_LISTCONTENT = /^\((.*)\)$/,
     RE_LITERAL = /\{(\d+)\}$/,
@@ -253,9 +254,26 @@ Parser.prototype._resUntagged = function() {
       val = parseId(m[5], this._literals);
     else if (type === 'status')
       val = parseStatus(m[5], this._literals);
-    else if (type === 'fetch')
+    else if (type === 'fetch') {
+      if (m[5]) {
+        var p = RE_BODYQUOTED.exec(m[5]);
+        if (p) {
+          // BODY as quoted string -- stream it
+          var which = p[1], body = parseQuotedString(p[2]);
+          this._body = new ReadableStream();
+          this._body._read = EMPTY_READCB;
+          m[5] = m[5].replace(RE_BODYQUOTED, '');
+          this.emit('body', this._body, {
+            seqno: num,
+            which: which,
+            size: body.length
+          });
+          this._body.push(body);
+          this._body.push(null);
+        }
+      }
       val = parseFetch(m[5], this._literals);
-    else if (type === 'namespace')
+    } else if (type === 'namespace')
       val = parseNamespaces(m[5], this._literals);
     else if (type === 'esearch')
       val = parseESearch(m[5], this._literals);
@@ -302,6 +320,10 @@ function indexOfCh(buffer, len, i, ch) {
     }
   }
   return r;
+}
+
+function parseQuotedString(text) {
+  return text.replace(/\\(\\|")/g, '$1');
 }
 
 function parseTextCode(text, literals) {


### PR DESCRIPTION
When a client fetches a body section from a Yahoo imap server, if the section length is short enough, it will be returned as a quoted string instead of a literal. This pull request should handles such case.
