### PR TITLE
Remove useless _tryreads because they cause problems.

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -163,7 +163,6 @@ Parser.prototype._resTagged = function() {
     // non-BODY literal -- buffer it
     this._buffer = this._buffer.replace(RE_LITERAL, LITPLACEHOLDER);
     this._literallen = parseInt(m[1], 10);
-    this._tryread(this._literallen);
   } else {
     var m = RE_TAGGED.exec(this._buffer),
         tagnum = parseInt(m[1], 10),
@@ -202,7 +201,6 @@ Parser.prototype._resUntagged = function() {
     // non-BODY literal -- buffer it
     this._buffer = this._buffer.replace(RE_LITERAL, LITPLACEHOLDER);
     this._literallen = parseInt(m[1], 10);
-    this._tryread(this._literallen);
   } else if (m = RE_UNTAGGED.exec(this._buffer)) {
     this._buffer = '';
     // normal single line response


### PR DESCRIPTION
These cases are already handled in _parse function, see https://github.com/mscdex/node-imap/issues/326
