### PR TITLE
Remove useless _tryreads because they cause problems.

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -163,7 +163,6 @@ Parser.prototype._resTagged = function() {
     // non-BODY literal -- buffer it
     this._buffer = this._buffer.replace(RE_LITERAL, LITPLACEHOLDER);
     this._literallen = parseInt(m[1], 10);
-    this._tryread(this._literallen);
   } else {
     var m = RE_TAGGED.exec(this._buffer),
         tagnum = parseInt(m[1], 10),
@@ -202,7 +201,6 @@ Parser.prototype._resUntagged = function() {
     // non-BODY literal -- buffer it
     this._buffer = this._buffer.replace(RE_LITERAL, LITPLACEHOLDER);
     this._literallen = parseInt(m[1], 10);
-    this._tryread(this._literallen);
   } else if (m = RE_UNTAGGED.exec(this._buffer)) {
     this._buffer = '';
     // normal single line response


### PR DESCRIPTION
These cases are already handled in _parse function.

Resending the pull request, because it wasn't broken after all. The literal data is read from the stream buffer instead of the already read buffer and that is the wrong location. If we unshift the whole rest of the read buffer back to the stream and try to read the literal from there it should work just fine.

https://github.com/mscdex/node-imap/issues/326 is still related.
