### PR TITLE
Fix imap.openBox not returning with highestmodseq`

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -15,7 +15,7 @@ var CH_LF = 10,
     RE_SEQNO = /^\* (\d+)/,
     RE_LISTCONTENT = /^\((.*)\)$/,
     RE_LITERAL = /\{(\d+)\}$/,
-    RE_UNTAGGED = /^\* (?:(OK|NO|BAD|BYE|FLAGS|ID|LIST|LSUB|SEARCH|STATUS|CAPABILITY|NAMESPACE|PREAUTH|SORT|THREAD|ESEARCH|QUOTA|QUOTAROOT)|(\d+) (EXPUNGE|FETCH|RECENT|EXISTS))(?: (?:\[([^\]]+)\] )?(.+))?$/i,
+    RE_UNTAGGED = /^\* (?:(OK|NO|BAD|BYE|FLAGS|ID|LIST|LSUB|SEARCH|STATUS|CAPABILITY|NAMESPACE|PREAUTH|SORT|THREAD|ESEARCH|QUOTA|QUOTAROOT)|(\d+) (EXPUNGE|FETCH|RECENT|EXISTS))(?:(?: \[([^\]]+)\])?(?: (.+))?)?$/i,
     RE_TAGGED = /^A(\d+) (OK|NO|BAD) (?:\[([^\]]+)\] )?(.+)$/i,
     RE_CONTINUE = /^\+(?: (?:\[([^\]]+)\] )?(.+))?$/i,
     RE_CRLF = /\r\n/g,
@@ -799,7 +799,7 @@ function decodeBytes(buf, encoding, offset, mlen, state) {
       return;
     } else if (isPartial) {
       // RFC2047 says that each decoded encoded word "MUST represent an integral
-      // number of characters. A multi-octet character may not be split across 
+      // number of characters. A multi-octet character may not be split across
       // adjacent encoded-words." However, some MUAs appear to go against this,
       // so we join broken encoded words separated by linear white space until
       // we can successfully decode or we see a change in encoding


### PR DESCRIPTION
Hello,

I noticed that when using `imap.openBox` the box in the response would not contain a highestmodseq despite the imap server sending it down. 

The problem was the server message `'* OK [HIGHESTMODSEQ 501328]'` not matching the RE_UNTAGGED regex correctly. The entirety of the [HIGHESTMODSEQ 501328] was being put into capture group 5 instead of 4 as the other commands do. This caused the message to be ignored by node-imap.

This does not happen on `imap.status`. The change just tweaks the regex, hopefully with no side effects.
