### PR TITLE
Fixed imap.status not returning with UIDNEXT.

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -477,7 +477,7 @@ Connection.prototype.status = function(boxName, cb) {
 
   boxName = escape(utf7.encode(''+boxName));
 
-  var info = [ 'MESSAGES', 'RECENT', 'UNSEEN', 'UIDVALIDITY' ];
+  var info = [ 'MESSAGES', 'RECENT', 'UNSEEN', 'UIDVALIDITY', 'UIDNEXT' ];
 
   if (this.serverSupports('CONDSTORE'))
     info.push('HIGHESTMODSEQ');


### PR DESCRIPTION
The documentation states that this should be returned with a status call.
