### PR TITLE
Fix the need for rejectUnauthorized being false.

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -105,6 +105,7 @@ Connection.prototype.connect = function() {
     for (var k in config.tlsOptions)
       tlsOptions[k] = config.tlsOptions[k];
     tlsOptions.socket = socket;
+    tlsOptions.host = config.host;
   }
 
   if (config.tls)
@@ -1633,6 +1634,7 @@ Connection.prototype._starttls = function() {
     for (var k in this._config.tlsOptions)
       tlsOptions[k] = this._config.tlsOptions[k];
     tlsOptions.socket = self._sock;
+    tlsOptions.host = this._config.host;
 
     self._sock = tls.connect(tlsOptions, function() {
       self._login();


### PR DESCRIPTION
The tlsOptions object should include a host for certificate validation.

The documentation available at :http://nodejs.org/api/tls.html#tls_tls_connect_port_host_options_callback is a bit confusing but the tls.js file from Node.js clearly uses the hostname from the options object to do its certificate validation.

A workaround for the current version of the library would be to add, for example, host: 'imap.google.com' to the tlsOptions object.

This fix was tested with gmail. With this change, the error "Hostname/IP doesn't match certificate's altnames" disappears. 
