### PR TITLE
Parser: join only consecutive q-encoded words

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -838,7 +838,7 @@ function decodeWords(str, state) {
 
   var bytes, m, i, j, leni, lenj, seq, replaces = [], lastReplace = {};
   
-  // join consecutive encoded words that have the same charset and encoding first
+  // join consecutive q-encoded words that have the same charset first
   while (m = RE_ENCWORD.exec(str)) {
     seq = {
       consecutive: (pendoffset > -1
@@ -854,7 +854,8 @@ function decodeWords(str, state) {
     lastReplace = replaces.length && replaces[replaces.length - 1];
     if (seq.consecutive
         && seq.charset === lastReplace.charset
-        && seq.encoding === lastReplace.encoding) {
+        && seq.encoding === lastReplace.encoding
+        && seq.encoding === 'q') {
       lastReplace.length += seq.length + seq.index - pendoffset;
       lastReplace.chunk += seq.chunk;
     } else {

--- a/test/test-parse-header.js
+++ b/test/test-parse-header.js
@@ -57,6 +57,13 @@ var CRLF = '\r\n';
     expected: { subject: [ 'abcdefghij ใน klmnopqr ไม่ขึ้น' ] },
     what: 'Folded header value (incomplete multi-byte character split)'
   },
+  { source: ['Subject: =?utf-8?B?Rlc6IOC4quC4tOC5iOC4h+C4oeC4tQ==?=', CRLF,
+             ' =?utf-8?B?4LiK4Li14Lin4Li04LiV4Lir4LiZ4LmJ4Liy4LiV?=', CRLF,
+             ' =?utf-8?B?4Liy4LmB4Lib4Lil4LiBIOC5hiDguKPguK3=?=', CRLF,
+             ' =?utf-8?Q?=E0=B8=9A=E0=B9=82=E0=B8=A5=E0=B8=81?=', CRLF],
+    expected: { subject: [ 'FW: สิ่งมีชีวิตหน้าตาแปลก ๆ รอบโลก' ] },
+    what: 'Folded header value (consecutive base64-encoded words)'
+  },
   // header with body
   { source: ['Subject: test subject', CRLF,
              'X-Another-Header: test', CRLF,


### PR DESCRIPTION
From #360, joining consecutive B encoded words before decoding will produce incorrect results. My bad.
