### PR TITLE
docs(UIDPLUS): correct doc on copy/move

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ Extensions Supported
 
     * The callback passed to append() will receive an additional argument (the UID of the appended message): < _integer_ >appendedUID.
 
-    * The callback passed to append()/seq.append() will receive an additional argument (the UID(s) of the copied message(s) in the destination mailbox): < _mixed_ >newUIDs. `newUIDs` can be an integer if just one message was copied, or a string for multiple messages (e.g. '100:103' or '100,125,130' or '100,200:201').
+    * The callback passed to copy(), move(), seq.copy(), seq.move() will receive an additional argument (the UID(s) of the copied message(s) in the destination mailbox): < _mixed_ >newUIDs. `newUIDs` can be an integer if just one message was copied, or a string for multiple messages (e.g. '100:103' or '100,125,130' or '100,200:201').
 
 * **RFC4551**
 


### PR DESCRIPTION
I think what you meant here is that copy/move can receiv a UID of the copied/moved message.

As append() was already taken care of.

Close this if I am wrong.
