### PR TITLE
esearch parser was failing on single digit items, like 'ALL 1'

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -329,7 +329,7 @@ function parseESearch(text, literals) {
     key = r[i].toLowerCase();
     val = r[i + 1];
     if (key === 'all')
-      val = val.split(',');
+      val = val.toString().split(',');
     attrs[key] = val;
   }
 


### PR DESCRIPTION
'val' could be of a number type and node was crashing on attempt to call non-existing method 'split' on it.
