### PR TITLE
Fix for values that may be understood as "numeric", i.e. has no .toLowerCase()

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -427,7 +427,7 @@ function parseFetch(text, literals, seqno) {
   var list = parseExpr(text, literals)[0], attrs = {}, m, body;
   // list is [KEY1, VAL1, KEY2, VAL2, .... KEYn, VALn]
   for (var i = 0, len = list.length, key, val; i < len; i += 2) {
-    key = list[i].toLowerCase();
+    key = list[i].toString().toLowerCase();
     val = list[i + 1];
     if (key === 'envelope')
       val = parseFetchEnvelope(val);


### PR DESCRIPTION
Did not dig into the code - so I'm not absolutely sure what this function does, but: The script crashed here for me for a key named "4826". Does not crash anymore when I make sure that we have a string.
