### PR TITLE
Added append LITERAL+ extension support

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -212,12 +212,7 @@ Connection.prototype.connect = function() {
       self.debug && self.debug('=> ' + inspect(CRLF));
       self._sock.write(CRLF);
     } else if (type === 'APPEND') {
-      var val = self._curReq.appendData;
-      if (Buffer.isBuffer(self._curReq.appendData))
-        val = val.toString('utf8');
-      self.debug && self.debug('=> ' + inspect(self._curReq.appendData));
-      self._sock.write(self._curReq.appendData);
-      self._sock.write(CRLF);
+      self._sockWriteAppendData(self._curReq.appendData);
     } else if (self._curReq.lines && self._curReq.lines.length) {
       var line = self._curReq.lines.shift() + '\r\n';
       self.debug && self.debug('=> ' + inspect(line));
@@ -278,6 +273,7 @@ Connection.prototype.end = function() {
 };
 
 Connection.prototype.append = function(data, options, cb) {
+  var literal = this.serverSupports('LITERAL+');
   if (typeof options === 'function') {
     cb = options;
     options = undefined;
@@ -323,10 +319,14 @@ Connection.prototype.append = function(data, options, cb) {
   }
   cmd += ' {';
   cmd += (Buffer.isBuffer(data) ? data.length : Buffer.byteLength(data));
-  cmd += '}';
+  cmd += (literal ? '+' : '') + '}';
 
   this._enqueue(cmd, cb);
-  this._queue[this._queue.length - 1].appendData = data;
+
+  if (literal)
+    this._queue[this._queue.length - 1].literalAppendData = data;
+  else
+    this._queue[this._queue.length - 1].appendData = data;
 };
 
 Connection.prototype.getBoxes = function(namespace, cb) {
@@ -1677,6 +1677,23 @@ Connection.prototype._processQueue = function() {
   var out = prefix + ' ' + this._curReq.fullcmd;
   this.debug && this.debug('=> ' + inspect(out));
   this._sock.write(out + CRLF, 'utf8');
+
+  if (! this._curReq.literalAppendData)
+    return;
+
+  // LITERAL+: we are appending a mesage, and not waiting for a reply
+  this._sockWriteAppendData(this._curReq.literalAppendData);
+};
+
+Connection.prototype._sockWriteAppendData = function(appendData)
+{
+  var val = appendData;
+  if (Buffer.isBuffer(appendData))
+    val = val.toString('utf8');
+
+  this.debug && this.debug('=> ' + inspect(val));
+  this._sock.write(val);
+  this._sock.write(CRLF);
 };
 
 Connection.prototype._enqueue = function(fullcmd, promote, cb) {


### PR DESCRIPTION
The client will automatically detect if the server supports
LITERAL+ during an append, and if so, will immediately send
the message data. This allows messages to be append to a
Microsoft Exchange server.
