### PR TITLE
Added socketTimeout option to ensure that OS-level timeouts are handled by node-imap

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -56,7 +56,7 @@ function Connection(config) {
 
   this._config = {
     socket: config.socket,
-    socketTimeout: config.socketTimeout,
+    socketTimeout: config.socketTimeout || 0,
     host: config.host || 'localhost',
     port: config.port || 143,
     tls: config.tls,
@@ -150,7 +150,7 @@ Connection.prototype.connect = function() {
   };
   this._sock.on('error', this._onError);
 
-  this._onSocketTimeout = function(){
+  this._onSocketTimeout = function() {
     clearTimeout(self._tmrConn);
     clearTimeout(self._tmrAuth);
     clearTimeout(self._tmrKeepalive);
@@ -158,7 +158,7 @@ Connection.prototype.connect = function() {
     self.debug && self.debug('[connection] Socket timeout');
 
     var err = new Error('Socket timed out while talking to server');
-    err.source = 'timeout';
+    err.source = 'socket-timeout';
     self.emit('error', err);
     socket.destroy();
   };


### PR DESCRIPTION
Hi,

> Eventually the OS will detect the dead connection, but typically after a much longer period of time (although most non-Windows platforms allow you to tweak these kinds of settings). (Brian, #423)

It won't. I waited 10 hours, and they still weren't.

> If you have any good suggestions for solving the problem, I'm all ears. (Brian, #423)

Here is my pull request to fix the issue.
Basically, I added a "socketTimeout" option in the configuration. Note that sockets can be created in two ways: in the constructor, or in _starttls. I cover both cases.

This ensures that OS-level timeouts can be set. This basically means that if the socket remains silent for X amount of time, the exception will be raised.
Note that I wasn't sure how much cleaning up you want to do in this kind of situation. At the moment, I clean up "the lot":

```
this._onSocketTimeout = function(){
  clearTimeout(self._tmrConn);
  clearTimeout(self._tmrAuth);
  clearTimeout(self._tmrKeepalive);
  self.state = 'disconnected';
  self.debug && self.debug('[connection] Socket timeout');

  var err = new Error('Socket timed out while talking to server');
  err.source = 'timeout';
  self.emit('error', err);
  socket.destroy();
}
```

Not sure if I went overboard. I am also not sure if you want to set self.state in case of a timeout error -- I think it makes sense.

Solves #423, which I closed.
