### PR TITLE
Fix a crash when parsing the first header line that starts with a whitespace

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -978,6 +978,8 @@ function parseHeader(str, noDecode) {
     if (lines[i].length === 0)
       break; // empty line separates message's header and body
     if (lines[i][0] === '\t' || lines[i][0] === ' ') {
+      if (!Array.isArray(header[h]))
+        continue; // ignore invalid first line
       // folded header content
       val = lines[i];
       if (!noDecode) {

--- a/test/test-parse-header.js
+++ b/test/test-parse-header.js
@@ -70,6 +70,11 @@ var CRLF = '\r\n';
     expected: { subject: [ 'รูปภาพที่ embed ในเนื้อเมลล์ไม่แสดง' ] },
     what: 'Folded header value (consecutive partial base64-encoded words)'
   },
+  { source: ['               ', CRLF,
+             'To: Foo', CRLF],
+    expected: { to: [ 'Foo' ] },
+    what: 'Invalid first line'
+  },
   // header with body
   { source: ['Subject: test subject', CRLF,
              'X-Another-Header: test', CRLF,


### PR DESCRIPTION
Hello, I just discovered that Gmail always prepend a first line which contains only whitespaces when viewing message source. That line can crash node-imap's Parser, throwing this error:

```
TypeError: Cannot read property 'length' of undefined
    at parseHeader (/Users/top/wavify/node-imap/lib/Parser.js:991:26)
```

This PR fixes this issue by ignoring any folded line with no preceding line.
