### PR TITLE
Remove useless mail event with entire that counts entire box as new after openBox

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1265,6 +1265,8 @@ Connection.prototype._resUntagged = function(info) {
       var prev = this._box.messages.total,
           now = info.num;
       this._box.messages.total = now;
+      if (this._box.name === '')
+        prev = now;
       if (now > prev && this.state === 'authenticated') {
         this._box.messages.new = now - prev;
         this.emit('mail', this._box.messages.new);


### PR DESCRIPTION
``` javascript
var Imap = require('map');
var imap = new Imap(opts);

imap.once('ready', function() {
    imap.openBox('INBOX', true, function(err, box) {
        console.log('Got inbox', box.messages.total);
    });
});

imap.on('mail', function(new) {
    console.log('New mail', new);
});
```

Before this patch the above code would print out

```
Got inbox 5052
New mail 5052
# Then when an actual message came in
New mail 1
```

Now the code above prints

```
Got inbox 5052
# Then when an actual message comes in
New mail 1
```
