### PR TITLE
make OR filter work

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1830,7 +1830,7 @@ function buildSearchQuery(options, extensions, info, isOrChild) {
   var searchargs = '', err, val;
   for (var i = 0, len = options.length; i < len; ++i) {
     var criteria = (isOrChild ? options : options[i]),
-        args = null,
+        args = (isOrChild ? null : options.slice(i+1)),
         modifier = (isOrChild ? '' : ' ');
     if (typeof criteria === 'string')
       criteria = criteria.toUpperCase();
@@ -1853,6 +1853,7 @@ function buildSearchQuery(options, extensions, info, isOrChild) {
       searchargs += ') (';
       searchargs += buildSearchQuery(args[1], extensions, info, true);
       searchargs += ')';
+      i = i+2
     } else {
       if (criteria[0] === '!') {
         modifier += 'NOT ';


### PR DESCRIPTION
With this change, the following IMAP filter now works as follows;
Unseen AND size<500MB AND (FROM : tedj7890@gmail.com OR abc@example.com OR xyz@public.com OR 'Tetsuo Seto')

var FIVE_HUNDRED_MB = (50*1024*1024).toString()
searchFilter: ['UNSEEN', ['SMALLER',FIVE_HUNDRED_MB], 'OR',
    ['OR', ['FROM','tedj7890@gmail.com'],['FROM','abc@example.com']],
    ['OR', ['FROM','xyz@public.com'],['FROM','Tetsuo Seto']]
  ],