### PR TITLE
Additional special use attribute '\\Important' used by Gmail

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -29,6 +29,7 @@ var MAX_INT = 9007199254740992,
       '\\Archive',
       '\\Drafts',
       '\\Flagged',
+      '\\Important',
       '\\Junk',
       '\\Sent',
       '\\Trash'


### PR DESCRIPTION
Would be very helpful if imap package can support one more special attribute.