### PR TITLE
Adding CRAM-MD5 server authentication

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1,4 +1,5 @@
 var tls = require('tls'),
+    crypto = require('crypto'),
     Socket = require('net').Socket,
     EventEmitter = require('events').EventEmitter,
     inherits = require('util').inherits,
@@ -242,6 +243,8 @@ Connection.prototype.connect = function() {
       self._curReq.oauthError = new Buffer(info.text, 'base64').toString('utf8');
       self.debug && self.debug('=> ' + inspect(CRLF));
       self._sock.write(CRLF);
+    } else if (/^AUTHENTICATE CRAM-MD5/.test(self._curReq.fullcmd)) {
+      self._authCRAMMD5(info.text);
     } else if (type === 'APPEND') {
       self._sockWriteAppendData(self._curReq.appendData);
     } else if (self._curReq.lines && self._curReq.lines.length) {
@@ -1653,9 +1656,14 @@ Connection.prototype._login = function() {
           cmd += ' ' + escape(self._config.xoauth2);
         self._enqueue(cmd, checkCaps);
       } else if (self._config.user && self._config.password) {
+        if (self.serverSupports('AUTH=CRAM-MD5')) {
+          cmd = 'AUTHENTICATE CRAM-MD5';
+        } else {
+          cmd = 'LOGIN "' + escape(self._config.user) + '" "'
+                      + escape(self._config.password) + '"';
+        }
         self._caps = undefined;
-        self._enqueue('LOGIN "' + escape(self._config.user) + '" "'
-                      + escape(self._config.password) + '"', checkCaps);
+        self._enqueue(cmd, checkCaps);
       } else {
         err = new Error('No supported authentication method(s) available. '
                         + 'Unable to login.');
@@ -1665,6 +1673,17 @@ Connection.prototype._login = function() {
     } else
       reentry();
   });
+};
+
+Connection.prototype._authCRAMMD5 = function(secret) {
+  var decodedSecret, hmac, response;
+  decodedSecret = new Buffer(secret, 'base64').toString('utf8');
+  hmac = crypto.createHmac('md5', this._config.password)
+          .update(decodedSecret)
+          .digest('hex');
+  response = new Buffer(this._config.user + ' ' + hmac).toString('base64');
+  this.debug && this.debug('=> ' + response);
+  this._sock.write(response + CRLF, 'utf8');
 };
 
 Connection.prototype._starttls = function() {


### PR DESCRIPTION
Closes #337 by adding support for CRAM-MD5 authentication.

I am unable to run the tests (they currently fail on master as well), but have tested this against my IMAP server which runs CRAM-MD5 authentication (debug log below to show it).

Would love some help figuring out how to provide a test suite for this as well. 

Also I was unsure about how I'm sending the challenge response. I tried using `#_enqueue` but it was adding information to the start of the command; the challenge needs to be send with no leading information.  

I noticed this structure:

```js
  if (this._curReq.type === 'IDLE' || this._curReq.type === 'NOOP')
    prefix = this._curReq.type;
  else
    prefix = 'A' + (this._tagcount++);
```

In `#_processQueue` but that uses the current request type to handle it's munging of the command. The challenge response has no type -- it's literally just the base64 encoded HMAC digest with the username pre-pended with a space, so I'm just writing directly to the socket and leaving `this._curReq` alone (which seems to be the best case out of all the methods I tried.)

```> {"name":"nodemailapp","hostname":"NewOSX","pid":36165,"level":60,"msg":"[connection] Connected to host","time":"2015-04-03T21:13:48.183Z","v":0}
{"name":"nodemailapp","hostname":"NewOSX","pid":36165,"level":60,"msg":"<= '* OK [CAPABILITY IMAP4rev1 LITERAL+ SASL-IR LOGIN-REFERRALS ID ENABLE IDLE AUTH=PLAIN AUTH=CRAM-MD5] Dovecot ready.'","time":"2015-04-03T21:13:48.261Z","v":0}
{"name":"nodemailapp","hostname":"NewOSX","pid":36165,"level":60,"msg":"=> 'A0 CAPABILITY'","time":"2015-04-03T21:13:48.262Z","v":0}
{"name":"nodemailapp","hostname":"NewOSX","pid":36165,"level":60,"msg":"<= '* CAPABILITY IMAP4rev1 LITERAL+ SASL-IR LOGIN-REFERRALS ID ENABLE IDLE AUTH=PLAIN AUTH=CRAM-MD5'","time":"2015-04-03T21:13:48.341Z","v":0}
{"name":"nodemailapp","hostname":"NewOSX","pid":36165,"level":60,"msg":"<= 'A0 OK Pre-login capabilities listed, post-login capabilities have more.'","time":"2015-04-03T21:13:48.341Z","v":0}
{"name":"nodemailapp","hostname":"NewOSX","pid":36165,"level":60,"msg":"=> 'A1 AUTHENTICATE CRAM-MD5'","time":"2015-04-03T21:13:48.342Z","v":0}
{"name":"nodemailapp","hostname":"NewOSX","pid":36165,"level":60,"msg":"<= '+ PDIzNDc3NTc0MzQ1NDYwMTUuMTQyODA5NjAxMEBtYWlsLnNlbGZhc3NlbWJsZWQub3JnPg=='","time":"2015-04-03T21:13:48.421Z","v":0}
{"name":"nodemailapp","hostname":"NewOSX","pid":36165,"level":60,"msg":"=> [SECRET RESPONSE COMMENTED OUT]","time":"2015-04-03T21:13:48.421Z","v":0}
{"name":"nodemailapp","hostname":"NewOSX","pid":36165,"level":60,"msg":"<= '* CAPABILITY IMAP4rev1 LITERAL+ SASL-IR LOGIN-REFERRALS ID ENABLE IDLE SORT SORT=DISPLAY THREAD=REFERENCES THREAD=REFS MULTIAPPEND UNSELECT CHILDREN NAMESPACE UIDPLUS LIST-EXTENDED I18NLEVEL=1 CONDSTORE QRESYNC ESEARCH ESORT SEARCHRES WITHIN CONTEXT=SEARCH LIST-STATUS'","time":"2015-04-03T21:13:48.504Z","v":0}
{"name":"nodemailapp","hostname":"NewOSX","pid":36165,"level":60,"msg":"<= 'A1 OK Logged in'","time":"2015-04-03T21:13:48.504Z","v":0}```

