### PR TITLE
Connection.js: socket needs to be set up in the case of tls

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -124,7 +124,7 @@ Connection.prototype.connect = function() {
   }
 
   if (config.tls)
-    this._sock = tls.connect(tlsOptions, onconnect);
+    socket = this._sock = tls.connect(tlsOptions, onconnect);
   else {
     socket.once('connect', onconnect);
     this._sock = socket;


### PR DESCRIPTION
Otherwise the event handlers are set up on the wrong socket object.