### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   },
   "engines": { "node": ">=0.8.0" },
   "keywords": [ "imap", "mail", "email", "reader", "client" ],
-  "licenses": [ { "type": "MIT", "url": "http://github.com/mscdex/node-imap/raw/master/LICENSE" } ],
+  "license": "MIT",
   "repository": { "type": "git", "url": "http://github.com/mscdex/node-imap.git" }
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/