### PR TITLE
substituted undefined config with self._config

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1694,7 +1694,8 @@ Connection.prototype._starttls = function() {
 
     self._sock.on('error', self._onError);
     self._sock.on('timeout', this._onSocketTimeout);
-    self._sock.setTimeout(config.socketTimeout);
+    self._sock.setTimeout(self._config.socketTimeout);
+
 
     self._parser.setStream(self._sock);
   });


### PR DESCRIPTION
It appear to affect only starttls connection.
After the change, I can successfully connect.

I don't add test because I'm not able to successfully run existing ones...