### PR TITLE
allow flags with $ and no leading char

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-node_modules

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -630,10 +630,7 @@ Connection.prototype._store = function(which, uids, cfg, cb) {
   if (!Array.isArray(items))
     items = [items];
   for (var i = 0, len = items.length; i < len; ++i) {
-    if (isFlags) {
-      if (items[i][0] !== '\\')
-        items[i] = '\\' + items[i];
-    } else {
+    if (!isFlags) {
       // keyword contains any char except control characters (%x00-1F and %x7F)
       // and: '(', ')', '{', ' ', '%', '*', '\', '"', ']'
       if (RE_INVALID_KW_CHARS.test(items[i])) {

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -150,6 +150,7 @@ Connection.prototype.connect = function() {
     self.emit('error', err);
   };
   this._sock.on('error', this._onError);
+  socket.on('error', this._onError);
 
   this._onSocketTimeout = function() {
     clearTimeout(self._tmrConn);

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -124,7 +124,7 @@ Connection.prototype.connect = function() {
   }
 
   if (config.tls)
-    this._sock = tls.connect(tlsOptions, onconnect);
+    socket = this._sock = tls.connect(tlsOptions, onconnect);
   else {
     socket.once('connect', onconnect);
     this._sock = socket;

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -150,7 +150,6 @@ Connection.prototype.connect = function() {
     self.emit('error', err);
   };
   this._sock.on('error', this._onError);
-  socket.on('error', this._onError);
 
   this._onSocketTimeout = function() {
     clearTimeout(self._tmrConn);

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -123,6 +123,7 @@ Connection.prototype.connect = function() {
     tlsOptions.socket = socket;
   }
 
+  var baseSocket = socket;
   if (config.tls)
     socket = this._sock = tls.connect(tlsOptions, onconnect);
   else {
@@ -282,7 +283,7 @@ Connection.prototype.connect = function() {
     socket.destroy();
   }, config.connTimeout);
 
-  socket.connect(config.port, config.host);
+  baseSocket.connect(config.port, config.host);
 };
 
 Connection.prototype.serverSupports = function(cap) {


### PR DESCRIPTION
This allows setting flags on messages that have no leading \ (such as $ or just plain text, both of which seem to be in common use). The danger removing this helper feature is that some client may be expecting the node-imap to add the \ for it and this would break that.

I could add this as an option to setFlags, addFlags, delFlags, etc -- but I thought I float this first. It seems 'wrong' to have the library adding the flag leading characters at all at this level.