### PR TITLE
allow flags with $ and no leading char

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -630,10 +630,7 @@ Connection.prototype._store = function(which, uids, cfg, cb) {
   if (!Array.isArray(items))
     items = [items];
   for (var i = 0, len = items.length; i < len; ++i) {
-    if (isFlags) {
-      if (items[i][0] !== '\\')
-        items[i] = '\\' + items[i];
-    } else {
+    if (!isFlags) {
       // keyword contains any char except control characters (%x00-1F and %x7F)
       // and: '(', ')', '{', ' ', '%', '*', '\', '"', ']'
       if (RE_INVALID_KW_CHARS.test(items[i])) {


### PR DESCRIPTION
This allows setting flags on messages that have no leading \ (such as $ or just plain text, both of which seem to be in common use). The danger removing this helper feature is that some client may be expecting the node-imap to add the \ for it and this would break that.

I could add this as an option to setFlags, addFlags, delFlags, etc -- but I thought I float this first. It seems 'wrong' to have the library adding the flag leading characters at all at this level.

Looking at the specs it may be these are 'keywords' mixed in with the flags. If that's the case maybe we just need to filter out non \ flags when getting flags. My application level problem was I was getting the flags, adding a flag/removing a flag, then trying to put them back and getting an error. The built in add/del flags functions had the same issue.
