### PR TITLE
Need to run connect on the base socket in node 5.1.1

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -123,6 +123,7 @@ Connection.prototype.connect = function() {
     tlsOptions.socket = socket;
   }
 
+  var baseSocket = socket;
   if (config.tls)
     this._sock = tls.connect(tlsOptions, onconnect);
   else {
@@ -282,7 +283,7 @@ Connection.prototype.connect = function() {
     socket.destroy();
   }, config.connTimeout);
 
-  socket.connect(config.port, config.host);
+  baseSocket.connect(config.port, config.host);
 };
 
 Connection.prototype.serverSupports = function(cap) {


### PR DESCRIPTION
The connect code for TLS creates a base socket and passes that to TLS connect in the options, then way later in connect we call connect on the socket with a host and port.

It looks like the expectation is you can call TLS.connect with an unconnected socket and 'host' set in options, then later call TLS.connect again on the TLS socket it returned but this time with a host and port rather than options. This worked in 0.12 but now in 5.1.1 a connection on the base socket is never attempted.

I added a patch to call connect on the original (base) socket rather than calling it again on the tls socket and that seems to work as expected. This isn't ready for prime time, I didn't test on any of the older versions.
