### PR TITLE
fixed parser unhandled exception when a non-standard messageId exists

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -660,6 +660,9 @@ function parseExpr(o, literals, result, start, useBrackets, isEnvelope) {
   }
   for (var i = start, len = o.str.length; i < len; ++i) {
     var isMessageId = isEnvelope && result.length == 9;
+    if (isMessageId) {
+      useBrackets = false;
+    }
     if (!inQuote) {
       if (isBody) {
         if (o.str[i] === ']') {

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -641,7 +641,7 @@ function parseEnvelopeAddresses(list) {
   return addresses;
 }
 
-function parseExpr(o, literals, result, start, useBrackets) {
+function parseExpr(o, literals, result, start, useBrackets, isEnvelope) {
   start = start || 0;
   var inQuote = false,
       lastPos = start - 1,
@@ -659,6 +659,7 @@ function parseExpr(o, literals, result, start, useBrackets) {
     isTop = true;
   }
   for (var i = start, len = o.str.length; i < len; ++i) {
+    var isMessageId = isEnvelope && result.length == 9;
     if (!inQuote) {
       if (isBody) {
         if (o.str[i] === ']') {
@@ -667,13 +668,15 @@ function parseExpr(o, literals, result, start, useBrackets) {
           lastPos = i;
           isBody = false;
         }
-      } else if (o.str[i] === '"')
+      } else if (o.str[i] === '"' && !isMessageId)
         inQuote = true;
-      else if (o.str[i] === ' '
+      else if ((o.str[i] === ' ' && !isMessageId)
                || o.str[i] === ')'
                || (useBrackets && o.str[i] === ']')) {
         if (i - (lastPos + 1) > 0) {
           val = convStr(o.str.substring(lastPos + 1, i), literals);
+          if (val === 'ENVELOPE')
+            isEnvelope = true;
           result.push(val);
         }
         if ((o.str[i] === ')' || (useBrackets && o.str[i] === ']')) && !isTop)
@@ -687,7 +690,7 @@ function parseExpr(o, literals, result, start, useBrackets) {
           lastPos = i - 5;
         } else {
           var innerResult = [];
-          i = parseExpr(o, literals, innerResult, i + 1, useBrackets);
+          i = parseExpr(o, literals, innerResult, i + 1, useBrackets, isEnvelope);
           lastPos = i;
           result.push(innerResult);
         }

--- a/test/test-parse-expr.js
+++ b/test/test-parse-expr.js
@@ -68,8 +68,19 @@ var assert = require('assert'),
     ],
     what: 'Triple backslash in quoted string (GH Issue #345)'
   },
-  { source: 'ENVELOPE ("Wed, 16 Dec 2015 16:19:25 +0100 (CET)" "Subject Line" ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) NIL NIL NIL "<message@id.with" <quote.angleBracket@and.space>"))',
+  { source: 'FLAGS (\\Seen)'
+        + ' ENVELOPE ("Wed, 16 Dec 2015 16:19:25 +0100 (CET)"'
+        + ' "Subject Line" ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL))'
+        + ' NIL NIL NIL "<message@id.with" <quote.angleBracket@and.space>")'
+        + ' INTERNALDATE "17-Jul-1996 02:44:25 -0700"'
+        + ' BODYSTRUCTURE (("TEXT" "PLAIN" ("CHARSET" "US-ASCII") NIL NIL "7BIT" 1152 23)'
+        + ' ("TEXT" "PLAIN" ("CHARSET" "US-ASCII" "NAME" "cc.diff")'
+        + ' "<960723163407.20117h@cac.washington.edu>" "Compiler diff"'
+        + ' "BASE64" 4554 73)'
+        + ' "MIXED")',
     expected: [
+      'FLAGS',
+      [ '\\Seen' ],
       'ENVELOPE',
       ['Wed, 16 Dec 2015 16:19:25 +0100 (CET)', //date
         'Subject Line', //subject
@@ -80,11 +91,50 @@ var assert = require('assert'),
         null, //cc
         null, //bcc
         null, //in-reply-to
-        '<message@id.with" <quote.angleBracket@and.space>', // messageId
-      ]
+        '<message@id.with" <quote.angleBracket@and.space>' // messageId
+      ],
+      'INTERNALDATE',
+      '17-Jul-1996 02:44:25 -0700',
+      'BODYSTRUCTURE',
+      [ [ 'TEXT',
+        'PLAIN',
+        [ 'CHARSET', 'US-ASCII' ],
+        null,
+        null,
+        '7BIT',
+        1152,
+        23 ],
+        [ 'TEXT',
+          'PLAIN',
+          [ 'CHARSET', 'US-ASCII', 'NAME', 'cc.diff' ],
+          '<960723163407.20117h@cac.washington.edu>',
+          'Compiler diff',
+          'BASE64',
+          4554,
+          73 ],
+        'MIXED' ]
     ],
     what: 'envelope with bad messageId'
   },
+  { source: 'ENVELOPE ("Thu, 17 Dec 2015 16:08:55 +0800 (CST)" "Subject Line"'
+       + ' ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL))'
+       + ' NIL NIL NIL "<message.id.with@[brackets]>")',
+    expected: [
+      'ENVELOPE',
+      ['Thu, 17 Dec 2015 16:08:55 +0800 (CST)', //date
+        'Subject Line', //subject
+        [[null, null, null, null]], //from
+        [[null, null, null, null]], //sender
+        [[null, null, null, null]], //replyto
+        [[null, null, null, null]], //to
+        null, //cc
+        null, //bcc
+        null, //in-reply-to
+        '<message.id.with@[brackets]>' // messageId
+      ]
+    ],
+    what: 'envelope with another bad messageId'
+  }
 ].forEach(function(v) {
   var result;
 

--- a/test/test-parse-expr.js
+++ b/test/test-parse-expr.js
@@ -48,16 +48,17 @@ var assert = require('assert'),
     expected: ['Who does not think \\"IMAP" is terrible\\bad?'],
     what: 'Quoted string with escaped chars #4'
   },
-  { source: 'ENVELOPE ("Wed, 30 Mar 2014 02:38:23 +0100" "=?ISO-8859-1?Q?##ALLCAPS##123456## - ?= =?ISO-8859-1?Q?[ALERT][P3][ONE.TWO.FR] ?= =?ISO-8859-1?Q?Some Subject Line \\"D:\\\\\\"?=" (("Test Account (Rltvty L)" NIL "account" "test.com")) (("Test Account (Rltvty L)" NIL "account" "test.com")) ((NIL NIL "account" "test.com")) ((NIL NIL "one.two" "test.fr") (NIL NIL "two.three" "test.fr")) NIL NIL NIL "<message@test.eu>")',
+  {
+    source: 'ENVELOPE ("Wed, 30 Mar 2014 02:38:23 +0100" "=?ISO-8859-1?Q?##ALLCAPS##123456## - ?= =?ISO-8859-1?Q?[ALERT][P3][ONE.TWO.FR] ?= =?ISO-8859-1?Q?Some Subject Line \\"D:\\\\\\"?=" (("Test Account (Rltvty L)" NIL "account" "test.com")) (("Test Account (Rltvty L)" NIL "account" "test.com")) ((NIL NIL "account" "test.com")) ((NIL NIL "one.two" "test.fr") (NIL NIL "two.three" "test.fr")) NIL NIL NIL "<message@test.eu>")',
     expected: [
       'ENVELOPE',
-      [ 'Wed, 30 Mar 2014 02:38:23 +0100',
+      ['Wed, 30 Mar 2014 02:38:23 +0100',
         '=?ISO-8859-1?Q?##ALLCAPS##123456## - ?= =?ISO-8859-1?Q?[ALERT][P3][ONE.TWO.FR] ?= =?ISO-8859-1?Q?Some Subject Line "D:\\"?=',
-        [ [ 'Test Account (Rltvty L)', null, 'account', 'test.com' ] ],
-        [ [ 'Test Account (Rltvty L)', null, 'account', 'test.com' ] ],
-        [ [ null, null, 'account', 'test.com' ] ],
-        [ [ null, null, 'one.two', 'test.fr' ],
-          [ null, null, 'two.three', 'test.fr' ]
+        [['Test Account (Rltvty L)', null, 'account', 'test.com']],
+        [['Test Account (Rltvty L)', null, 'account', 'test.com']],
+        [[null, null, 'account', 'test.com']],
+        [[null, null, 'one.two', 'test.fr'],
+          [null, null, 'two.three', 'test.fr']
         ],
         null,
         null,
@@ -66,6 +67,23 @@ var assert = require('assert'),
       ]
     ],
     what: 'Triple backslash in quoted string (GH Issue #345)'
+  },
+  { source: 'ENVELOPE ("Wed, 16 Dec 2015 16:19:25 +0100 (CET)" "Subject Line" ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) NIL NIL NIL "<message@id.with" <quote.angleBracket@and.space>"))',
+    expected: [
+      'ENVELOPE',
+      ['Wed, 16 Dec 2015 16:19:25 +0100 (CET)', //date
+        'Subject Line', //subject
+        [[null, null, null, null]], //from
+        [[null, null, null, null]], //sender
+        [[null, null, null, null]], //replyto
+        [[null, null, null, null]], //to
+        null, //cc
+        null, //bcc
+        null, //in-reply-to
+        '<message@id.with" <quote.angleBracket@and.space>', // messageId
+      ]
+    ],
+    what: 'envelope with bad messageId'
   },
 ].forEach(function(v) {
   var result;

--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -452,6 +452,31 @@ var CR = '\r', LF = '\n', CRLF = CR + LF;
               ],
     what: 'QuotaRoot'
   },
+  { source: ['* 456 FETCH (UID 2013 FLAGS (\\Seen) INTERNALDATE "16-Dec-2015 23:19:35 +0800" ENVELOPE ("Wed, 16 Dec 2015 16:19:25 +0100 (CET)" "Subject Line" ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) NIL NIL NIL "<message@id.with" <quote.angleBracket@and.space>"))', CRLF],
+    expected: [ { type: 'fetch',
+                  num: 456,
+                  textCode: undefined,
+                  text:
+                  { uid: 2013,
+                    flags: [ '\\Seen' ],
+                    internaldate: new Date('Wed Dec 16 2015 09:19:35 GMT-0600 (CST)'),
+                    envelope:
+                    { date: new Date('Wed Dec 16 2015 09:19:25 GMT-0600 (CST)'),
+                      subject: 'Subject Line',
+                      from: [],
+                      sender: [],
+                      replyTo: [],
+                      to: [],
+                      cc: null,
+                      bcc: null,
+                      inReplyTo: null,
+                      messageId: '<message@id.with" <quote.angleBracket@and.space>'
+                    }
+                  }
+                }
+              ],
+    what: 'envelope with bad messageId'
+  },
 ].forEach(function(v) {
   var ss = new require('stream').Readable(), p, result = [];
   ss._read = function(){};

--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -477,6 +477,31 @@ var CR = '\r', LF = '\n', CRLF = CR + LF;
               ],
     what: 'envelope with bad messageId'
   },
+  { source: ['* 159 FETCH (UID 5287 FLAGS () INTERNALDATE "18-Dec-2015 00:11:41 +0800" ENVELOPE ("Thu, 17 Dec 2015 16:08:55 +0800 (CST)" "Subject Line" ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) NIL NIL NIL "<message.id.with@[brackets]>"))', CRLF],
+    expected: [ { type: 'fetch',
+      num: 159,
+      textCode: undefined,
+      text:
+      { uid: 5287,
+        flags: [],
+        internaldate: new Date('Thu Dec 17 2015 10:11:41 GMT-0600 (CST)'),
+        envelope:
+        { date: new Date('Thu Dec 17 2015 02:08:55 GMT-0600 (CST)'),
+          subject: 'Subject Line',
+          from: [],
+          sender: [],
+          replyTo: [],
+          to: [],
+          cc: null,
+          bcc: null,
+          inReplyTo: null,
+          messageId: '<message.id.with@[brackets]>'
+        }
+      }
+    }
+    ],
+    what: 'envelope with another bad messageId'
+  }
 ].forEach(function(v) {
   var ss = new require('stream').Readable(), p, result = [];
   ss._read = function(){};


### PR DESCRIPTION
A few times a day, I see emails with very strange `Message-ID` headers, like the example below:

```
Message-ID: <redacted.redacted@email.redacted.com" <support@email.redacted.com>
```

When fetching the ENVELOPE for messages with a message Id like the one above, an unhandled exception occurs inside the `Parser.parseFetch` method, because the `Parser.parseExpr` method has returned an invalid result.

For example, with this envelope string:

```
'ENVELOPE ("Wed, 16 Dec 2015 16:19:25 +0100 (CET)" "Subject Line" ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) NIL NIL NIL "<message@id.with" <quote.angleBracket@and.space>"))'
```

 `Parser.parseExpr` currently returns the following:

```
[ 'ENVELOPE',
  [ 'Wed, 16 Dec 2015 16:19:25 +0100 (CET)',
    'Subject Line',
    [ [ null, null, null, null ] ],
    [ [ null, null, null, null ] ],
    [ [ null, null, null, null ] ],
    [ [ null, null, null, null ] ],
    null,
    null,
    null,
    '<message@id.with',
    '<quote.angleBracket@and.space>"))' ],
  'Wed,',
  16,
  'Dec',
  2015,
  '16:19:25',
  '+0100',
  [ 'CET' ],
  ' "Subjec',
  'Line" ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) ((NIL NIL NIL NIL)) NIL NIL NIL "<message@id.with" <quote.angleBracket@and.space>"' ]
```

And `Parser.parseFetch` will throw this exception:

```
JS Exception: TypeError: Object CET has no method 'toLowerCase'
    at Parser.parseFetch (/Users/epinzur/projects/node-imap/lib/Parser.js:431:19)
    at Parser._resUntagged (/Users/epinzur/projects/node-imap/lib/Parser.js:257:24)
    at Parser._parse (/Users/epinzur/projects/node-imap/lib/Parser.js:137:16)
    at Parser._tryread (/Users/epinzur/projects/node-imap/lib/Parser.js:82:15)
    at Readable.Parser._cbReadable (/Users/epinzur/projects/node-imap/lib/Parser.js:53:12)
    at Readable.emit (events.js:92:17)

```

My changes to `Parser.parseExpr` fix this issue by knowing to ignore space & quote characters when processing the messageId parameter of the envelope.