### PR TITLE
ignore uid,flags,internalDate,modseq where fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,10 @@ Connection Instance Methods
 
     Valid `options` properties are:
 
+      * **uid** - _boolean_ - Fetch the message uid. **Default:** true
+      * **flags** - _boolean_ - Fetch the message flags. **Default:** true
+      * **modseq** - _boolean_ - Fetch the message modseq. **Default:** true if server supports `CONDSTORE`
+      * **internalDate** - _boolean_ - Fetch the internal date. **Default:** true
       * **markSeen** - _boolean_ - Mark message(s) as read when fetched. **Default:** false
       * **struct** - _boolean_ - Fetch the message structure. **Default:** false
       * **envelope** - _boolean_ - Fetch the message envelope. **Default:** false

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -799,13 +799,13 @@ Connection.prototype._fetch = function(which, uids, options) {
     fetching.push('X-GM-LABELS');
   }
   if (this.serverSupports('CONDSTORE') && !this._box.nomodseq)
-    if(!options || options.modseq===undefined || options.modseq === true)
+    if(!options || options.modseq !== true)
       fetching.push('MODSEQ');
-  if(!options || options.uid===undefined || options.uid === true)
+  if(!options || options.uid !== false)
     fetching.push('UID');
-  if(!options || options.flags===undefined || options.flags === true)
+  if(!options || options.flags !== true)
     fetching.push('FLAGS');
-  if(!options || options.internalDate===undefined || options.internalDate === true)
+  if(!options || options.internalDate !== true)
     fetching.push('INTERNALDATE');
 
   var modifiers;

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -799,11 +799,14 @@ Connection.prototype._fetch = function(which, uids, options) {
     fetching.push('X-GM-LABELS');
   }
   if (this.serverSupports('CONDSTORE') && !this._box.nomodseq)
-    fetching.push('MODSEQ');
-
-  fetching.push('UID');
-  fetching.push('FLAGS');
-  fetching.push('INTERNALDATE');
+    if(!options || options.modseq===undefined || options.modseq === true)
+      fetching.push('MODSEQ');
+  if(!options || options.uid===undefined || options.uid === true)
+    fetching.push('UID');
+  if(!options || options.flags===undefined || options.flags === true)
+    fetching.push('FLAGS');
+  if(!options || options.internalDate===undefined || options.internalDate === true)
+    fetching.push('INTERNALDATE');
 
   var modifiers;
 

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -798,8 +798,9 @@ Connection.prototype._fetch = function(which, uids, options) {
     fetching.push('X-GM-MSGID');
     fetching.push('X-GM-LABELS');
   }
-  if (this.serverSupports('CONDSTORE') && !this._box.nomodseq)
-    if(!options || options.modseq !== false)
+  if (this.serverSupports('CONDSTORE') 
+    && !this._box.nomodseq 
+    && (!options || options.modseq !== false))
       fetching.push('MODSEQ');
   if(!options || options.uid !== false)
     fetching.push('UID');


### PR DESCRIPTION
fetch uid,flags,internalDate,modseq default and ignore if not required
当我选择按不同的  `partID` 来下载邮件的内容的时候，除了下载 `headers`的时候之外，我不希望再次下载 uid, flags, internalDate, modseq 的信息。 因为这会浪费许多的流量