### PR TITLE
Add new option "extensions" (Array) to Connection.prototype._fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ Connection Instance Methods
       * **envelope** - _boolean_ - Fetch the message envelope. **Default:** false
       * **size** - _boolean_ - Fetch the RFC822 size. **Default:** false
       * **modifiers** - _object_ - Fetch modifiers defined by IMAP extensions. **Default:** (none)
+      * **extensions** - _array_ - Fetch custom fields defined by IMAP extensions, e.g. ['X-MAILBOX', 'X-REAL-UID']. **Default:** (none)
       * **bodies** - _mixed_ - A string or Array of strings containing the body part section to fetch. **Default:** (none) Example sections:
 
           * 'HEADER' - The message header

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -815,10 +815,11 @@ Connection.prototype._fetch = function(which, uids, options) {
       fetching.push('BODYSTRUCTURE');
     if (options.size)
       fetching.push('RFC822.SIZE');
-    if (Array.isArray(options.extensions))
+    if (Array.isArray(options.extensions)) {
       options.extensions.forEach(function (extension) {
         fetching.push(extension.toUpperCase());
       });
+    }
     cmd += fetching.join(' ');
     if (options.bodies !== undefined) {
       var bodies = options.bodies,

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -815,6 +815,10 @@ Connection.prototype._fetch = function(which, uids, options) {
       fetching.push('BODYSTRUCTURE');
     if (options.size)
       fetching.push('RFC822.SIZE');
+    if (Array.isArray(options.extensions))
+      options.extensions.forEach(function (extension) {
+        fetching.push(extension.toUpperCase());
+      });
     cmd += fetching.join(' ');
     if (options.bodies !== undefined) {
       var bodies = options.bodies,


### PR DESCRIPTION
This would add a simple but general support to fetch custom fields based on server extensions.

A real-world example is fetching Dovecot's X-MAILBOX and X-REAL-UID that are useful when working with Dovecot's virtual/all folder, for example, when searching messages across all mailboxes. Those special fields are documented (or let's say mentioned) here: http://www.dovecot.org/list/dovecot/2014-September/097907.html

We can also look for a different solution if this particular one is too direct.