### PR TITLE
Support mail box names containing square brackets

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -375,7 +375,7 @@ function parseQuotaRoot(text, literals) {
 }
 
 function parseBoxList(text, literals) {
-  var r = parseExpr(text, literals);
+  var r = parseExpr(text, literals, null, null, false);
   return {
     flags: r[0],
     delimiter: r[1],


### PR DESCRIPTION
The "Airmail" app for OS X creates a mailbox called "[Airmail]" and some sub-folders. This doesn't seem to be supported, as the result passed to the "getBoxes()" callback looks broken. It's expected to return something like:

`[Airmail], [Airmail].To Do, [Airmail].Done, [Airmail].Memo, [Airmail].Snooze`
however, it returns
`[Airmail], Airmail, [Airmail.To Do]` (all other boxes are missing)

