### PR TITLE
Connection: mute a server bad error caused by fetching pure blank box

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1807,11 +1807,24 @@ function validateUIDList(uids, noThrow) {
         if (len > 1)
           uids = ['*'];
         break;
+      } else if (uids[i].startsWith('0')) {
+        var err = new Error('UID/seqno can\'t be or starts with Non-positive number');
+        if (noThrow)
+          return err;
+        else
+          throw err;
       } else if (RE_NUM_RANGE.test(uids[i]))
         continue;
+
     }
     intval = parseInt(''+uids[i], 10);
-    if (isNaN(intval)) {
+    if (intval === 0) {
+      var err = new Error('UID/seqno can\'t be Non-positive number');
+      if (noThrow)
+        return err;
+      else
+        throw err;
+    } else if (isNaN(intval)) {
       var err = new Error('UID/seqno must be an integer, "*", or a range: '
                           + uids[i]);
       if (noThrow)


### PR DESCRIPTION
when fetching a pure blank box which never received emails, some server will return error:

```
events.js:141
      throw er; // Unhandled 'error' event
      ^

Error: The specified message set is invalid.
    at Connection._resTagged (/Users/sinux/node_test/for_imap/node_modules/imap/lib/Connection.js:1499:11)
    at Parser.<anonymous> (/Users/sinux/node_test/for_imap/node_modules/imap/lib/Connection.js:193:10)
    at emitOne (events.js:77:13)
    at Parser.emit (events.js:169:7)
    at Parser._resTagged (/Users/sinux/node_test/for_imap/node_modules/imap/lib/Parser.js:175:10)
    at Parser._parse (/Users/sinux/node_test/for_imap/node_modules/imap/lib/Parser.js:139:16)
    at Parser._tryread (/Users/sinux/node_test/for_imap/node_modules/imap/lib/Parser.js:82:15)
    at TLSSocket.Parser._cbReadable (/Users/sinux/node_test/for_imap/node_modules/imap/lib/Parser.js:53:12)
    at emitNone (events.js:67:13)
    at TLSSocket.emit (events.js:166:7)
    at emitReadable_ (_stream_readable.js:411:10)
    at emitReadable (_stream_readable.js:405:7)
    at readableAddChunk (_stream_readable.js:157:11)
    at TLSSocket.Readable.push (_stream_readable.js:110:10)
```

this can be catched in bodyEmitter's error event handler, but this is not an error actually, at least box's other property is healthy, so I think this error should be mute?
