### PR TITLE
Problem: I cannot do complex OR clauses as I cannot use AND inside OR

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1869,6 +1869,12 @@ function buildSearchQuery(options, extensions, info, isOrChild) {
       searchargs += ') (';
       searchargs += buildSearchQuery(args[1], extensions, info, true);
       searchargs += ')';
+    } else if (criteria === 'AND' && isOrChild) {
+      if (args.length < 2)
+        throw new Error('AND must have more than one argument');
+
+      searchargs += buildSearchQuery(args[0], extensions, info, true);
+      searchargs += buildSearchQuery(args.slice(1), extensions, info, false);
     } else {
       if (criteria[0] === '!') {
         modifier += 'NOT ';


### PR DESCRIPTION
within search OR operation only allow one search key while the protocol allow multiple.
To solve this I added special operator called AND which is allow only within OR clause, the AND just allow unbound array which is inline into the OR operation.

Some examples, if I want to the following IMAP query I cannot do that before this PR:

OR (UNKEWORD DISCARD) (BEFORE 24-AUG-2016 UNSEEN)

trying to do the following yield error:
[['OR', [['UNKEYWORD', 'DISCARD'], [['BEFORE', '24-AUG-2016'], UNSEEN]]]

Now I can do:
[['OR', [['UNKEYWORD', 'DISCARD'], [['AND', ['BEFORE', '24-AUG-2016'], UNSEEN]]]]

which works

If you have another solution for the problem that will be great.