### PR TITLE
Parse box names with square brackets and no quotes correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -28,6 +28,7 @@ var CH_LF = 10,
     RE_QENC = /(?:=([a-fA-F0-9]{2}))|_/g,
     RE_SEARCH_MODSEQ = /^(.+) \(MODSEQ (.+?)\)$/i,
     RE_LWS_ONLY = /^[ \t]*$/;
+    RE_BOX_NAME = /(\(.*\) "\/" )(.*)/;
 
 function Parser(stream, debug) {
   if (!(this instanceof Parser))
@@ -375,6 +376,18 @@ function parseQuotaRoot(text, literals) {
 }
 
 function parseBoxList(text, literals) {
+  text = text.replace(RE_BOX_NAME, function(match, p1, p2, offset, str) {
+    if (!p2) {
+      return str
+    }
+    if (p2[0] === '"' && p2[p2.length - 1] === '"') {
+      return p1 + p2
+    }
+    if (p2[0] === "'" && p2[p2.length - 1] === "'") {
+      return p1 + p2
+    }
+    return p1 + '"' + p2 + '"'
+  })
   var r = parseExpr(text, literals);
   return {
     flags: r[0],
@@ -1020,6 +1033,7 @@ function parseHeader(str, noDecode) {
 
 exports.Parser = Parser;
 exports.parseExpr = parseExpr;
+exports.parseBoxList = parseBoxList;
 exports.parseEnvelopeAddresses = parseEnvelopeAddresses;
 exports.parseBodyStructure = parseBodyStructure;
 exports.parseHeader = parseHeader;

--- a/test/test-parse-box-list.js
+++ b/test/test-parse-box-list.js
@@ -1,0 +1,82 @@
+var parseBoxList = require('../lib/Parser').parseBoxList;
+
+var assert = require('assert'),
+    inspect = require('util').inspect;
+
+[
+  { source: '(\\Noselect) "/" ""',
+    expected: {
+      flags: [
+        "\\Noselect"
+      ],
+      delimiter: "/",
+      name: ""
+    },
+    what: 'Simple box info, empty name'
+  },
+  { source: '(\\HasChildren) "/" "INBOX"',
+    expected: {
+      flags: [
+        "\\HasChildren",
+      ],
+      delimiter: "/",
+      name: "INBOX"
+    },
+    what: 'Simple box info, name has quotes'
+  },
+  { source: '(\\HasNoChildren) "/" Archive',
+    expected: {
+      flags: [
+        "\\HasNoChildren"
+      ],
+      delimiter: "/",
+      name: "Archive"
+    },
+    what: 'Simple box info, name does not have quotes'
+  },
+  { source: '(\\HasChildren \\Noselect) "/" "[Gmail]/All Mail"',
+    expected: {
+      flags: [
+        "\\HasChildren",
+        "\\Noselect"
+      ],
+      delimiter: "/",
+      name: "[Gmail]/All Mail"
+    },
+    what: 'Simple box info, name has brackets and has quotes'
+  },
+  { source: '(\\HasChildren \\Noselect) "/" [Airmail]/To Do',
+    expected: {
+      flags: [
+        "\\HasChildren",
+        "\\Noselect"
+      ],
+      delimiter: "/",
+      name: "[Airmail]/To Do"
+    },
+    what: 'Simple box info, name has brackets and does not have quotes'
+  },
+].forEach(function(v) {
+  var result;
+
+  try {
+    result = parseBoxList(v.source);
+  } catch (e) {
+    console.log(makeMsg(v.what, 'JS Exception: ' + e.stack));
+    return;
+  }
+
+  assert.deepEqual(result,
+                   v.expected,
+                   makeMsg(v.what,
+                           'Result mismatch:'
+                           + '\nParsed: ' + inspect(result, false, 10)
+                           + '\nExpected: ' + inspect(v.expected, false, 10)
+                   )
+                  );
+});
+
+function makeMsg(what, msg) {
+  return '[' + what + ']: ' + msg;
+}
+


### PR DESCRIPTION
`parseBoxList` did not correctly parse box names that have brackets and
do not have quotes. For example:

`'(\\HasChildren \\Noselect) "/" [Airmail]/To Do'`, would return the
name `Airmail`, instead of `[Airmail]/To Do`. This is because `parseExpr` parses
anything within [] or () as a list, unless it's wrapped in quotes.

Given that `parseExpr` is used in many other cases, I did not want to
break this assumption and unknowingly break something else. Instead, I
updates `parseBoxList` to wrap the name in quotes before passing it to
`parseExpr` if it does not have quotes.

This commit also adds tests for several of these cases

(also add a .gitignore)