### PR TITLE
Convert the body to uppercase before parsing

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -213,7 +213,10 @@ Connection.prototype.connect = function() {
     // because 'HEADER.FIELDS (TO FROM)' really is equivalent to
     // 'HEADER.FIELDS ("TO" "FROM")' and some servers will actually send the
     // quoted form even if the client did not use quotes
-    var thisbody = parseExpr(info.which);
+    // It also converts the body to upper case, since the IMAP RFC
+    // states that flags should be matched in a case insensitive
+    // manner.
+    var thisbody = parseExpr(info.which.toUpperCase());
     for (var i = 0, len = toget.length; i < len; ++i) {
       if (_deepEqual(thisbody, toget[i])) {
         toget.splice(i, 1);


### PR DESCRIPTION
This allows for matching header flags where the case of the flags in
the return data is different than the case in the request.

Fixes #639