### PR TITLE
Connection: add leading zero to single digit date

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -338,7 +338,7 @@ Connection.prototype.append = function(data, options, cb) {
     if (!isDate(options.date))
       throw new Error('`date` is not a Date object');
     cmd += ' "';
-    cmd += options.date.getDate();
+    cmd += ('0' + options.date.getDate()).slice(-2);
     cmd += '-';
     cmd += MONTHS[options.date.getMonth()];
     cmd += '-';


### PR DESCRIPTION
yandex.ru imap server does not accept new messages with customized arrival date.

Problem looks like this:
```
=> 'A6 APPEND "test2" "7-Nov-2016 18:49:23 +0200" {160+}'
=> 'From: Fred Foobar <foobar@Blurdybloop.COM>[skipped]
<= 'A6 BAD Command syntax error. sc=jwOWLg0ZsiE1_221858_22j'
```

Message can be accepted after adding a leading zero "**7**-Nov-2016" -> "**07**-Nov-2016".
```
=> 'A6 APPEND "test2" "07-Nov-2016 18:49:23 +0200" {160+}'
=> 'From: Fred Foobar <foobar@Blurdybloop.COM>[skipped]
<= 'A6 OK [APPENDUID 1506098273 40] APPEND Completed.'
```