### PR TITLE
check the socket is connected or not when socket is going to connect.

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -283,11 +283,13 @@ Connection.prototype.connect = function() {
     socket.destroy();
   }, config.connTimeout);
 
-  socket.connect({
-    port: config.port,
-    host: config.host,
-    localAddress: config.localAddress
-  });
+  if (isUndefinedOrNull(socket.remoteAddress)) {
+    socket.connect({
+        port: config.port,
+        host: config.host,
+        localAddress: config.localAddress
+    });
+  }
 };
 
 Connection.prototype.serverSupports = function(cap) {


### PR DESCRIPTION
use case:
when i used socks module as proxy to visit imap.gmail.com, the SocksClient already connected. So, i got the error like this:
error:  { Error: connect EISCONN 64.233.187.109:993 - Local (10.0.2.6:56125)
    at Object._errnoException (util.js:1024:11)
    at _exceptionWithHostPort (util.js:1046:20)
    at internalConnect (net.js:971:16)
    at GetAddrInfoReqWrap.emitLookup [as callback] (net.js:1106:7)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:97:10)
  code: 'EISCONN',
  errno: 'EISCONN',
  syscall: 'connect',
  address: '64.233.187.109',
  port: 993,
  source: 'socket' }

I think when the socket is connected, we should not connect it again.