### PR TITLE
Add possibility to add multiple OR's in queries

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1870,15 +1870,23 @@ function buildSearchQuery(options, extensions, info, isOrChild) {
       throw new Error('Unexpected search option data type. '
                       + 'Expected string or array. Got: ' + typeof criteria);
     if (criteria === 'OR') {
-      if (args.length !== 2)
-        throw new Error('OR must have exactly two arguments');
+      var argsLen = args.length;
+      var s = 'OR ';
+      if (argsLen !== 2) {
+        if (argsLen < 2)
+          throw new Error('OR must have at least two arguments');
+        s = s.repeat(args.length - 1);
+      }
       if (isOrChild)
-        searchargs += 'OR (';
+        searchargs += s + '(';
       else
-        searchargs += ' OR (';
-      searchargs += buildSearchQuery(args[0], extensions, info, true);
-      searchargs += ') (';
-      searchargs += buildSearchQuery(args[1], extensions, info, true);
+        searchargs += ' ' + s + '(';
+      argsLen--;
+      for (var j = 0; j < argsLen ; j++) {
+        searchargs += buildSearchQuery(args[j], extensions, info, true);
+        searchargs += ') (';
+      }
+      searchargs += buildSearchQuery(args[argsLen], extensions, info, true);
       searchargs += ')';
     } else {
       if (criteria[0] === '!') {


### PR DESCRIPTION
Regarding the tests, I am not really familiar with the framework. Basically
```
["OR", ["FROM", "m1@asd.com"], ["FROM", "m2@asd.com"], ["FROM", "m3@asd.com"], ["FROM", "m4@asd.com"]]
```
should get translated to
```
OR OR OR (FROM "m1@asd.com") (FROM "m2@asd.com") (FROM "m3@asd.com") (FROM "m4@asd.com")
```
Because IMAP is in polish form the OR's should arrange just right.
Could you please add this test?