### PR TITLE
Connection: Set TLS servername default to host

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -117,6 +117,8 @@ Connection.prototype.connect = function() {
 
   if (config.tls) {
     tlsOptions = {};
+    // servername must be set to prevent issues with some imap server and openssl 1.1.1
+    tlsOptions.servername = config.host;
     tlsOptions.host = config.host;
     // Host name may be overridden the tlsOptions
     for (var k in config.tlsOptions)


### PR DESCRIPTION
Server name must be set for the SNI (Server Name Indication) TLS 
extension to work with openssl version 1.1.1 and some imap servers.   
Fix : mscdex#724