### PR TITLE
Potential fix for error with unhandled ECONNRESET

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -149,6 +149,9 @@ Connection.prototype.connect = function() {
     self.debug && self.debug('[connection] Error: ' + err);
     err.source = 'socket';
     self.emit('error', err);
+    if(err.code === 'ECONNRESET') { // other side of the TCP conversation abruptly closed its end of the connection.
+      socket.emit('close', err) // so we need close too, and final user of this package can reestablish connection
+    }
   };
   this._sock.on('error', this._onError);
 


### PR DESCRIPTION
This error simply means that the other side closed the connection in a way that was probably not normal.

An example is: a socket connection can be closed by the other party abruptly due to several reasons and you will see this error / exception on your side.

In this case we need close our socket too. Before this fix I experienced the following behaviour:
- everything works great
- after long time this error occured, probably it can be connected with logout from gmail or network error, I do not know
- application could detect error, but does not reset connection
- only restart of all system allows to establish connection again

Now I want to listen in my application on connection close and end, then reset connection in my own code. I invite to discuss if it is good solution, because of I feel it is ok, but do not know how to test it.

Issue in this project
> https://github.com/mscdex/node-imap/issues/710

Issue in dependent project
> https://github.com/jcreigno/nodejs-mail-notifier/issues/47

Further reading
> https://www.quora.com/What-does-%E2%80%9CError-read-ECONNRESET%E2%80%9D-mean