### PR TITLE
removed unnecessary Buffer.toString() with hardcoded utf8 encoding

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1745,12 +1745,8 @@ Connection.prototype._processQueue = function() {
 
 Connection.prototype._sockWriteAppendData = function(appendData)
 {
-  var val = appendData;
-  if (Buffer.isBuffer(appendData))
-    val = val.toString('utf8');
-
-  this.debug && this.debug('=> ' + inspect(val));
-  this._sock.write(val);
+  this.debug && this.debug('=> ' + inspect(appendData));
+  this._sock.write(appendData);
   this._sock.write(CRLF);
 };
 


### PR DESCRIPTION
If a message consists of parts with charsets other than `UTF-8` (e.g. `ISO-8859`), converting the buffer to a string with fixed encoding breaks special characters like umlauts.
As `net.Socket.write()` excepts a Buffer as the first parameter, converting it to string is unnecessary anyways, so removing the `Buffer.toString()` easily fixes that problem.