### PR TITLE
fix issue when servername not match the hsot. the certificate will got an error with ERR_TLS_CERT_ALTNAME_INVALID

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -60,6 +60,7 @@ function Connection(config) {
     socket: config.socket,
     socketTimeout: config.socketTimeout || 0,
     host: config.host || 'localhost',
+    servername: config.servername || 'localhost',
     port: config.port || 143,
     tls: config.tls,
     tlsOptions: config.tlsOptions,
@@ -118,7 +119,7 @@ Connection.prototype.connect = function() {
   if (config.tls) {
     tlsOptions = {};
     // servername must be set to prevent issues with some imap server and openssl 1.1.1
-    tlsOptions.servername = config.host;
+    tlsOptions.servername = config.servername || config.host
     tlsOptions.host = config.host;
     // Host name may be overridden the tlsOptions
     for (var k in config.tlsOptions)

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -60,7 +60,7 @@ function Connection(config) {
     socket: config.socket,
     socketTimeout: config.socketTimeout || 0,
     host: config.host || 'localhost',
-    servername: config.servername || 'localhost',
+    servername: config.servername,
     port: config.port || 143,
     tls: config.tls,
     tlsOptions: config.tlsOptions,


### PR DESCRIPTION
fix issue when servername not match the hsot. the certificate will got an error with ERR_TLS_CERT_ALTNAME_INVALID

```javascript
  var imap = new Imap({
  user: "username",
  password: "password",
  host: "hostname/ipaddress",
  servername: "server fqdn", //optional
  port: port,
  tls: true,
});
```
