### PR TITLE
Switch to safe-utf 7 to avoid vulnerability notifications

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -4,7 +4,7 @@ var tls = require('tls'),
     inherits = require('util').inherits,
     inspect = require('util').inspect,
     isDate = require('util').isDate,
-    utf7 = require('utf7').imap;
+    utf7 = require('safe-utf7').imap;
 
 var Parser = require('./Parser').Parser,
     parseExpr = require('./Parser').parseExpr,

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -4,7 +4,7 @@ var EventEmitter = require('events').EventEmitter,
     inherits = require('util').inherits,
     inspect = require('util').inspect;
 
-var utf7 = require('utf7').imap,
+var utf7 = require('safe-utf7').imap,
     jsencoding; // lazy-loaded
 
 var CH_LF = 10,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An IMAP module for node.js that makes communicating with IMAP servers easy",
   "main": "./lib/Connection",
   "dependencies": {
-    "safe-utf7": ">=1.0.4"
+    "safe-utf7": ">=1.0.6"
   },
   "scripts": {
     "test": "node test/test.js"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An IMAP module for node.js that makes communicating with IMAP servers easy",
   "main": "./lib/Connection",
   "dependencies": {
-    "safe-utf7": ">=1.0.3"
+    "safe-utf7": ">=1.0.4"
   },
   "scripts": {
     "test": "node test/test.js"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 { "name": "imap",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "author": "Brian White <mscdex@mscdex.net>",
   "description": "An IMAP module for node.js that makes communicating with IMAP servers easy",
   "main": "./lib/Connection",
   "dependencies": {
-    "utf7": ">=1.0.2"
+    "safe-utf7": ">=1.0.3"
   },
   "scripts": {
     "test": "node test/test.js"


### PR DESCRIPTION
I've been working with this library recently for a personal project, and I'm hugely grateful for the work that's gone into it!  The problem I ran into is that semver, a dependency of utf7 has a known vulnerability:

```bash
$ npm audit
# npm audit report

semver  <5.7.2
Severity: moderate
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
fix available via `npm audit fix --force`
Will install utf7@1.0.1, which is a breaking change
node_modules/semver
  utf7  >=1.0.2
  Depends on vulnerable versions of semver
  node_modules/utf7

2 moderate severity vulnerabilities

To address all issues (including breaking changes), run:
  npm audit fix --force
```

Unfortunately, Konstantin, who created the utf7 library, never published the code on a public repository where a Pull request could be submitted.  I've reached out to him directly, but in the meantime, I introduced https://github.com/alisonaquinas/node-safe-utf7 to resolve the issue. 